### PR TITLE
Use the upstream name "node", not Debian's "nodejs"

### DIFF
--- a/metapolator
+++ b/metapolator
@@ -1,4 +1,4 @@
-#!/usr/bin/env nodejs
+#!/usr/bin/env node
 
 // metapolator command line interface
 var requirejs = require('requirejs');


### PR DESCRIPTION
Fixes #130
