### PR TITLE
issue144: first support for continue loading on bad glyphs.

### DIFF
--- a/app/lib/project/ImportController.js
+++ b/app/lib/project/ImportController.js
@@ -46,7 +46,15 @@ define([
         
         // open the source ufo glyphs layer of an UFOv2
         this._sourceGlyphSet  = this._project.getNewGlyphSet(
-                false, [sourceUFODir, 'glyphs'].join('/'), undefined, 2);
+                false, [sourceUFODir, 'glyphs'].join('/'), undefined, 2 );
+
+        // tell us about errors instead of throwing it away
+        this._sourceGlyphSet.setReadErrorCallback( 
+            function( pm, glyph, message ) {
+                console.log("ImportController: Got an error loading glyph '" 
+                            + glyph.name + "' reason:" + message );
+                pm.rememberThatImportFailedForGlyph( glyph.name, message );
+            }.bind( null, this._master ));
     }
     var _p = ImportController.prototype;
     
@@ -67,10 +75,12 @@ define([
                                     +missing.join(', '));
         }
         console.log('importing ...');
-        for(;i<glyphs.length;i++)
-            Array.prototype.push.apply(rules, this.importGlyph(glyphs[i]));
-        
+        for(;i<glyphs.length;i++) {
+            var glyphName = glyphs[i];
+            Array.prototype.push.apply(rules, this.importGlyph( glyphName ));
+        }
         this._master.glyphSet.writeContents(false);
+        this._master.saveMetaData();
         
         // a namespace for the master ...
         cps = new AtNamespaceCollection(

--- a/app/lib/project/MetapolatorProject.js
+++ b/app/lib/project/MetapolatorProject.js
@@ -105,9 +105,13 @@ define([
         get: function(){ return this.dirName+'/layercontents.plist'; }
     });
     
-    _p.getNewGlyphSet = function(async, dirName, glyphNameFunc, UFOVersion) {
-        return GlyphSet.factory(
-                    async, this._io, dirName, glyphNameFunc, UFOVersion);
+    _p.getNewGlyphSet = function(async, dirName, glyphNameFunc, UFOVersion, cb ) {
+        var ret = GlyphSet.factory(
+            async, this._io, dirName, glyphNameFunc, UFOVersion );
+        if( cb !== undefined ) {
+            ret.setReadErrorCallback( cb );
+        }
+        return ret;
     }
     
     _p.init = function(dirName) {
@@ -342,7 +346,7 @@ define([
                                         this, masterName, sourceUFODir);
         importer.import(glyphs);
     }
-    
+
     _p.exportInstance = function(masterName, instanceName, precision) {
         // returns a models/Controller
         var model = this.open(masterName)

--- a/metapolator
+++ b/metapolator
@@ -6,7 +6,7 @@
 
 var path = require('path');
 var helmsman = require('helmsman');
-
+    
 var name = path.basename(process.argv[1], '.js');
 var cli = helmsman({localDir: __dirname + '/app/commands'});
 cli.on('--help', function(){


### PR DESCRIPTION
The idea is that a callback is passed down the readGlyph (with default in place). The callback can record what error happened for what glyphs. The default callback just throws an exception stopping processing.

A core change from the code just throwing an exception is that it now needs to "cleanup" after running the callback. This allows the callback to record that an error has happened and return. The calling code then needs to fix things, for example, by dropping the splines or skeletons in a single glyph if they are bad. This allows a partial import.

The advantage to this design is that the glyph and other metadata can still be imported. So for example, the "at" glyph from DroidSans which causes an error will still import the advance width and unicode hex settings for the glyph. The outline/contour is dropped however because it has import issues.

The new callback records which glyphs failed, why they failed, and when they failed. This way the GUI or tools can show these failures and allow reimport of just those previously failed glyphs.

I'm not 100% sure of where to record the metadata about glyph load failure. Two options present themselves; (a) have ProjectMaster record this information in a YAML file, and (b) push this information down to the Glyph object level. For (b) one might see the glif file as something like:

```
<glyph name="at" format="2">
  <advance width="1774"/>
  <unicode hex="0040"/>
 <importfailed reason="you have been bad" when="time_t here" />
...
```

The code for this PR implements option (a) because it was the simplest to do. YAML<->js object is simple.
