### PR TITLE
Allow commander argument descriptions to notate repeated args

### DIFF
--- a/app/commands/metapolator-dev-playground-cps
+++ b/app/commands/metapolator-dev-playground-cps
@@ -43,9 +43,6 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(CPSfile) {
-            if (program.args.length > program.max_args + 1)
-                program.help();
-
             var cpsString = io.readFile(false, CPSfile)
             var parameterRegistry = new Registry();
 

--- a/app/commands/metapolator-dev-playground-cps-algebra
+++ b/app/commands/metapolator-dev-playground-cps-algebra
@@ -27,9 +27,6 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(equation) {
-            if (program.args.length > program.max_args + 1)
-                program.help();
-
             function Operator() {
                 algebra.Operator.apply(this, Array.prototype.slice.call(arguments));
             }

--- a/app/commands/metapolator-dev-playground-cps-selectors
+++ b/app/commands/metapolator-dev-playground-cps-selectors
@@ -27,9 +27,6 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(masterName, selectors) {
-            if (program.args.length > program.max_args + 1)
-                program.help();
-
             var project = new MetapolatorProject(io);
             project.load();
             var controller = project.open(masterName);

--- a/app/commands/metapolator-export
+++ b/app/commands/metapolator-export
@@ -25,9 +25,6 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(masterName, instanceName) {
-            if (program.args.length > program.max_args + 1)
-                program.help();
-
             var project = new MetapolatorProject(io);
             project.load();
             project.exportInstance(masterName, instanceName, program.precision);

--- a/app/commands/metapolator-import
+++ b/app/commands/metapolator-import
@@ -29,9 +29,6 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(sourceUFO, targetMaster) {
-            if (program.args.length > program.max_args + 1)
-                program.help();
-
             // FIXME: very simple input validation, we'll need more I think
             if(targetMaster.indexOf('/') !== -1 || targetMaster.indexOf('\\') !== -1)
                 throw new CommandLineError('/ and \\ are not allowed in a '

--- a/app/commands/metapolator-init
+++ b/app/commands/metapolator-init
@@ -25,9 +25,6 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function (name) {
-            if (program.args.length > program.max_args + 1)
-                program.help();
-
             new MetapolatorProject.init(io, name);
         });
         program.parse(process.argv);

--- a/app/commands/metapolator-interpolate
+++ b/app/commands/metapolator-interpolate
@@ -33,9 +33,6 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(masters, interpolators) {
-            if (program.args.length > program.max_args + 1)
-                program.help();
-
             var names = masters.split(',');
             console.log(names);
             // FIXME: very simple input validation, we'll need more I think

--- a/app/commands/metapolator-red-pill
+++ b/app/commands/metapolator-red-pill
@@ -27,9 +27,6 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(projectDir) {
-            if (program.args.length > program.max_args + 1)
-                program.help();
-
             var express = require('express')
               , app = express()
             // expect require.main.filename to be path/to/metapolator-code/app/commands/<command>


### PR DESCRIPTION
Insist on arguments matching the command description, and hence remove
this code from the individual metapolator commands.
