### PR TITLE
2014sep/issue144v3: Use the new object API to ufoJS to curtail glif errors from being fatal

### DIFF
--- a/app/lib/project/ImportController.js
+++ b/app/lib/project/ImportController.js
@@ -46,14 +46,14 @@ define([
 
         // open the source ufo glyphs layer of an UFOv2
         this._sourceGlyphSet  = this._project.getNewGlyphSet(
-                false, [sourceUFODir, 'glyphs'].join('/'), undefined, 2 );
+                false, [sourceUFODir, 'glyphs'].join('/'), undefined, 2);
 
         // tell us about errors instead of throwing it away
         this._sourceGlyphSet.setReadErrorCallback( 
-            function( pm, glyph, message ) {
+            function( pm, d ) {
                 console.log("ImportController: Got an error loading glyph '" 
-                            + glyph.name + "' reason:" + message );
-                pm.rememberThatImportFailedForGlyph( glyph.name, message );
+                            + d.glyphName + "' reason:" + d.message );
+                pm.rememberThatImportFailedForGlyph( d.glyphName, d.message );
             }.bind( null, this._master ));
     }
     var _p = ImportController.prototype;

--- a/app/lib/project/MetapolatorProject.js
+++ b/app/lib/project/MetapolatorProject.js
@@ -136,6 +136,9 @@ define([
         this._io.mkDir(false, this.dirName+'/data');
         // create dir dirName/data/com.metaploator
         this._io.mkDir(false, this.dataDir);
+        // we store messages for the glyphs (failures etc)
+        // inside this subdir
+        this._io.mkDir(false, this.dataDir+'/messages');
         
         // project file:
         // create     this.dataDir/project.yaml => yaml({})

--- a/app/lib/project/ProjectMaster.js
+++ b/app/lib/project/ProjectMaster.js
@@ -30,7 +30,7 @@ define([
             this._data = {
                 type: 'ProjectMaster',
                 masters: {},
-                importFailures: {}
+                rememberedFailures: {}
             };
         }
     }
@@ -47,17 +47,31 @@ define([
         }
     });
 
-    _p.rememberThatImportFailedForGlyph = function( glyphName, reason ) {
-        this._data.importFailures[glyphName] = 
-            { 
-                name: glyphName, 
+    /**
+     * For each type of failure, which is just a string like 'import'
+     * etc, we can store the most recent failure for each glyph and
+     * why that happened. This might be extended to record more than
+     * just the latest failure, but knowing that an import failed 5
+     * times in a row is likely not as interesting to the user as
+     * knowing why it failed the last time it was tried.
+     */
+    _p.setRememberedFailure = function( type, glyphName, reason ) {
+        if( this._data.rememberedFailures[glyphName] === undefined ) {
+            this._data.rememberedFailures[glyphName] = {};
+        }
+        this._data.rememberedFailures[glyphName][ type ] =
+            {
+                name: glyphName,
                 reason: reason,
                 incidenttime: new Date(),
             };
     }
+    _p.rememberThatImportFailedForGlyph = function( glyphName, reason ) {
+        this.setRememberedFailure( 'import', glyphName, reason );
+    }
 
     Object.defineProperty(_p, 'metaDataFilePath', {
-        get: function(){ return this._project.dataDir+'/'+this._glyphSetDir+'.yaml';}
+        get: function(){ return this._project.dataDir+'/messages/'+this._glyphSetDir+'.yaml';}
     });
 
     _p.saveMetaData = function() {

--- a/metapolator
+++ b/metapolator
@@ -6,7 +6,7 @@
 
 var path = require('path');
 var helmsman = require('helmsman');
-    
+
 var name = path.basename(process.argv[1], '.js');
 var cli = helmsman({localDir: __dirname + '/app/commands'});
 cli.on('--help', function(){


### PR DESCRIPTION
This relies on the updates in ufoJS at https://github.com/graphicore/ufoJS/pull/17

I have also rolled in the update from v2 that allows other messages of interest to be recorded in the YAML. And the path of the file is in a subdirectory now.
