### PR TITLE
Fix use of errors in various commands

### DIFF
--- a/app/commands/metapolator-dev-playground-cps
+++ b/app/commands/metapolator-dev-playground-cps
@@ -16,7 +16,6 @@ requirejs.config(require('config'));
 if (require.main === module) {
     requirejs([
         'commander'
-      , 'metapolator/errors'
       , 'ufojs/tools/io/staticNodeJS'
       , 'metapolator/models/CPS/parsing/parseRules'
       , 'metapolator/models/Controller'
@@ -28,7 +27,6 @@ if (require.main === module) {
       , 'metapolator/models/CPS/Registry'
     ], function (
         program
-      , errors
       , io
       , parseRules
       , Controller
@@ -39,8 +37,6 @@ if (require.main === module) {
       , PenStrokePoint
       , Registry
     ) {
-        var CommandLineError = errors.CommandLine;
-
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(CPSfile) {

--- a/app/commands/metapolator-dev-playground-cps-algebra
+++ b/app/commands/metapolator-dev-playground-cps-algebra
@@ -16,10 +16,12 @@ requirejs.config(require('config'));
 if (require.main === module) {
     requirejs([
         'commander'
+      , 'metapolator/errors'
       , 'gonzales/gonzales'
       , 'metapolator/models/CPS/dataTypes/algebra'
     ], function (
         program
+      , errors
       , gonzales
       , algebra
     ) {
@@ -37,9 +39,9 @@ if (require.main === module) {
                   , bNum = typeof b !== 'number' ? parseFloat(b.literal) : b
                   ;
                 if(aNum !== aNum)
-                    throw new Error('Got NaN from: ' + a);
+                    throw new CommandLineError('Got NaN from: ' + a);
                 if(bNum !== bNum)
-                    throw new Error('Got NaN from: ' + b);
+                    throw new CommandLineError('Got NaN from: ' + b);
                 return this._routine(aNum, bNum);
             }
 

--- a/app/commands/metapolator-dev-playground-cps-selectors
+++ b/app/commands/metapolator-dev-playground-cps-selectors
@@ -23,8 +23,6 @@ if (require.main === module) {
       , io
       , MetapolatorProject
     ) {
-        var CommandLineError = errors.CommandLine;
-
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(masterName, selectors) {

--- a/app/commands/metapolator-import
+++ b/app/commands/metapolator-import
@@ -16,15 +16,19 @@ requirejs.config(require('config'));
 if (require.main === module) {
     requirejs([
         'commander'
+      , 'metapolator/errors'
       , 'metapolator/parseArgs'
       , 'ufojs/tools/io/staticNodeJS'
       , 'metapolator/project/MetapolatorProject'
     ], function (
         program
+      , errors
       , parseArgs
       , io
       , MetapolatorProject
     ) {
+        var CommandLineError = errors.CommandLine;
+
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(sourceUFO, targetMaster) {


### PR DESCRIPTION
Some used errors but didn’t import the error module; others _vice
versa_.

One was throwing a generic error instead of a CommandLineError.
