### PR TITLE
Add --port argument to red-pill; default is random

### DIFF
--- a/app/commands/metapolator-red-pill
+++ b/app/commands/metapolator-red-pill
@@ -222,10 +222,11 @@ if (require.main === module) {
                     next();
             });
 
-            app.listen(3000);
-            console.log('Metapolator: Serving the red pill.');
-            console.log('Open http://localhost:3000 in your browser.');
-        });
+            var server = app.listen(program.port || 0);
+            console.warn('Metapolator: Serving the red pill.');
+            console.warn('Open http://localhost:'+server.address().port+' in your browser.');
+        })
+        .option('-p, --port <n>', 'The port to listen on (default: random)', parseInt);
         program.parse(process.argv);
     }
 )}


### PR DESCRIPTION
Depending on your OS, the default port may be guaranteed not to clash
with an existing server (if one is available), or may simply have a good
chance.
