### PR TITLE
Fix new interpolate command

### DIFF
--- a/app/commands/metapolator-interpolate
+++ b/app/commands/metapolator-interpolate
@@ -51,19 +51,18 @@ if (require.main === module) {
             if (Math.abs(sum - 1.0) > .001)
                 console.warn('Proportions do not sum to (roughly) 1');
 
-            // Load project and create new master
             project.load();
-            newMaster = parseArgs.masterName(newMaster);
-            master = project.createMaster(newMaster);
-            cpsName = newMaster + '.cps';
-            master.cpsChain = [cpsName];
-            // FIXME: change the skeleton
 
             // Open existing masters
             for(i = 0; i < masters.length; i++) {
                 masters[i] = parseArgs.masterName(masters[i]);
                 project.open(masters[i]);
             }
+
+            // Create new master
+            newMaster = parseArgs.masterName(newMaster);
+            cpsName = newMaster + '.cps';
+            master = project.createMaster(newMaster, [cpsName], project._data.masters[masters[0]].skeleton);
 
             // Load interpolation CPS, adjust it, and get to work
             cps = '* {\n\

--- a/app/lib/project/ImportController.js
+++ b/app/lib/project/ImportController.js
@@ -44,7 +44,9 @@ define([
         if(this._project.hasMaster(masterName))
             this._master = this._project.getMaster(masterName);
         else
-            this._master = this._project.createMaster(masterName);
+            this._master = this._project.createMaster(masterName,
+                                                      [this._project.cpsOutputConverterFile, this._project.cpsGlobalFile, masterName + '.cps'],
+                                                      'skeleton.' + masterName);
 
         // open the source ufo glyphs layer of an UFOv2
         this._sourceGlyphSet  = this._project.getNewGlyphSet(

--- a/app/lib/project/MetapolatorProject.js
+++ b/app/lib/project/MetapolatorProject.js
@@ -299,23 +299,28 @@ define([
     }
     
     /**
-     * create a master entry for this masterName
-     * 
-     * and an entry in layercontents.plist:
-     * skeleton.masterName, glyphs.skeleton.masterName
+     * Create a master entry for this masterName, with the given cpsChain
+     * and skeleton.
+     *
+     * Also creates an entry in layercontents.plist: `skeleton`,
+     * glyphs.`skeleton`
+     *
+     * If any element does not exist, it is assumed the caller will create
+     * it before attempting to use the font.
      * 
      */
-    _p.createMaster = function(masterName) {
+    _p.createMaster = function(masterName, cpsChain, skeleton) {
         // get the name for this master from the CLI
         if(this.hasMaster(masterName))
             throw new ProjectError('Master "'+masterName+'" already exists.');
         var master = {};
         this._data.masters[masterName] = master;
-        master.cpsChain = [this.cpsOutputConverterFile, this.cpsGlobalFile, masterName + '.cps'];
+        master.cpsChain = cpsChain;
         
         // create a skeleton layer for this master
-        master.skeleton = 'skeleton.' + masterName;
-        this._createGlyphLayer(master.skeleton);
+        master.skeleton = skeleton;
+        if (skeleton === 'skeleton.' + masterName)
+            this._createGlyphLayer(master.skeleton);
 
         this._io.writeFile(false, this.projectFile, yaml.safeDump(this._data));
         


### PR DESCRIPTION
Apologies, the committed version was half-way between the primitive
version described by its commit log and what is presented here.

Add cpsChain and skeleton arguments to MetapolatorProject.createMaster,
and use them for import and interpolation.
