### PR TITLE
Make it possible always to specify the project directory

### DIFF
--- a/app/commands/metapolator-delete
+++ b/app/commands/metapolator-delete
@@ -5,7 +5,7 @@ __hash_bang_trick=/* exec /usr/bin/env node --harmony "$0" "$@"  # -*- mode: jav
 
 exports.command = {
     description: 'delete the given master'
-  , arguments: '<master>'
+  , arguments: '<[project/]master>'
 };
 
 var path = require('path');
@@ -28,11 +28,11 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(master) {
-            var project = new MetapolatorProject(io)
-                ;
+            var pm = parseArgs.projectMaster(io, master);
+            var project = pm[0];
+            master = pm[1];
             // Load project and delete master in it
             project.load();
-            master = parseArgs.masterName(master);
             project.deleteMaster(master);
         });
         program.parse(process.argv);

--- a/app/commands/metapolator-export
+++ b/app/commands/metapolator-export
@@ -4,8 +4,8 @@ __hash_bang_trick=/* exec /usr/bin/env node --harmony "$0" "$@"  # -*- mode: jav
 "use strict";
 
 exports.command = {
-    description: 'export the given master to directory <project>'
-  , arguments: '<master> <ufo>'
+    description: 'export a master to a UFO'
+  , arguments: '<[project/]master> <ufo>'
 };
 
 var path = require('path');
@@ -16,24 +16,28 @@ requirejs.config(require('config'));
 if (require.main === module) {
     requirejs([
         'commander'
+      , 'metapolator/parseArgs'
       , 'ufojs/tools/io/staticNodeJS'
       , 'metapolator/project/MetapolatorProject'
     ], function (
         program
+      , parseArgs
       , io
       , MetapolatorProject
 ) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
-        program.action(function(masterName, instanceName) {
-            var project = new MetapolatorProject(io);
+        program.action(function(master, instance) {
+            var pm = parseArgs.projectMaster(io, master);
+            var project = pm[0];
+            master = pm[1];
             project.load();
             
             // load all masters, because right now it is very confusing
             // when some masters are missing from the MOM
             project.masters.forEach(project.open, project);
             
-            project.exportInstance(masterName, instanceName, program.precision);
+            project.exportInstance(master, instance, program.precision);
         })
         .option('-p, --precision <n>', 'The number of decimal places to use in output coordinates, '
                                      + 'or -1 for no rounding',

--- a/app/commands/metapolator-import
+++ b/app/commands/metapolator-import
@@ -4,8 +4,8 @@ __hash_bang_trick=/* exec /usr/bin/env node --harmony "$0" "$@"  # -*- mode: jav
 "use strict";
 
 exports.command = {
-    description: 'import the given UFO directory to master <target-master>'
-  , arguments: '<ufo> <target-master>'
+    description: 'import a UFO to a master'
+  , arguments: '<ufo> <[project]/master>'
 };
 
 var path = require('path');
@@ -32,8 +32,9 @@ if (require.main === module) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
         program.arguments(exports.command.arguments);
         program.action(function(sourceUFO, targetMaster) {
-            var project = new MetapolatorProject(io);
-            targetMaster = parseArgs.masterName(targetMaster);
+            var pm = parseArgs.projectMaster(io, targetMaster);
+            var project = pm[0];
+            targetMaster = pm[1];
             project.load();
             project.import(targetMaster, sourceUFO, program.glyphs);
         })

--- a/app/commands/metapolator-red-pill
+++ b/app/commands/metapolator-red-pill
@@ -16,13 +16,13 @@ requirejs.config(require('config'));
 if (require.main === module) {
     requirejs([
         'commander'
+      , 'metapolator/parseArgs'
       , 'ufojs/tools/io/staticNodeJS'
-      , 'metapolator/project/MetapolatorProject'
       , 'fs'
     ], function (
         program
+      , parseArgs
       , io
-      , MetapolatorProject
       , fs
     ) {
         program._name = path.basename(process.argv[1], '.js').replace('-', ' ');
@@ -37,11 +37,7 @@ if (require.main === module) {
               , index = rootDir + '/app/red-pill.html'
             ;
 
-            if (projectDir === undefined || typeof(projectDir) == "object")
-                projectDir = process.cwd();
-            if (projectDir.slice(-1) != '/')
-                projectDir += '/';
-            // TODO: check if projectDir is indeed a metapolator project
+            var project = parseArgs.project(io, projectDir);
 
             // red-pill.html as index
             // all contents of /lib are served for get at /lib

--- a/app/lib/parseArgs.js
+++ b/app/lib/parseArgs.js
@@ -1,7 +1,9 @@
 define([
     'metapolator/errors'
+  , 'metapolator/project/MetapolatorProject'
 ], function (
     errors
+  , MetapolatorProject
 ) {
     "use strict";
 
@@ -15,6 +17,23 @@ define([
             throw new CommandLineError('/ and \\ are not allowed in a '
                                       + 'Master name: ' + s);
         return s;
+    }
+
+    parseArg.project = function (io, s) {
+        if (s === undefined || s == '')
+            s = process.cwd();
+        if (s.slice(-1) != '/')
+            s += '/';
+        var project = new MetapolatorProject(io, s);
+        if (!io.pathExists(false, project.dataDir))
+            throw new CommandLineError('\'' + s + '\' does not look '
+                                      + 'like a Metapolator project');
+        return project;
+    }
+
+    parseArg.projectMaster = function (io, s) {
+        var split = s.lastIndexOf('/');
+        return [parseArg.project(io, s.substr(0, split)), parseArg.masterName(s.substr(split + 1))];
     }
 
     return parseArg;

--- a/app/tests/lib/export/roundtrip.sh
+++ b/app/tests/lib/export/roundtrip.sh
@@ -20,14 +20,10 @@ rm -rf ${IMPORT_UFO}*.ufo ${export}*.ufo
 
 # Import and export the original font
 $METAPOLATOR init ${IMPORT_UFO}1.ufo
-cd ${IMPORT_UFO}1.ufo
-$METAPOLATOR import ../$font.ufo $MASTER_NAME
-$METAPOLATOR export --precision 3 $MASTER_NAME ../${export}1.ufo
-cd ..
+$METAPOLATOR import $font.ufo ${IMPORT_UFO}1.ufo/$MASTER_NAME
+$METAPOLATOR export --precision 3 ${IMPORT_UFO}1.ufo/$MASTER_NAME ${export}1.ufo
 
 # Import and export the first test export
 $METAPOLATOR init ${IMPORT_UFO}2.ufo
-cd ${IMPORT_UFO}2.ufo
-$METAPOLATOR import ../${export}1.ufo $MASTER_NAME
-$METAPOLATOR export --precision 3 $MASTER_NAME ../${export}2.ufo
-cd ..
+$METAPOLATOR import ${export}1.ufo ${IMPORT_UFO}2.ufo/$MASTER_NAME
+$METAPOLATOR export --precision 3 ${IMPORT_UFO}2.ufo/$MASTER_NAME ${export}2.ufo


### PR DESCRIPTION
This makes the syntax of import/export/delete consistent and simpler.

Also take advantage in the export tests, where we no longer need awkward
cd commands.

In the process, add validation for all project directory arguments.
