### PR TITLE
Make script properly idempotent, not raise an error

### DIFF
--- a/git-setup
+++ b/git-setup
@@ -2,18 +2,9 @@
 #
 # Configure git to make hacking on Metapolator easier
 # Read the rest of the script to see the new shortcuts added
-#
-# It is recommended also to use hub from https://hub.github.com/ which adds
-# and improves many git commands for github work
 
-# Instruct the user
-echo "Run \`git fetch upstream' to get upstream branches, PRs etc."
-
-# Exit on error, to make script idempotent: next command will give error if run twice
-set -e
-
-# Set upstream
-git remote add upstream https://github.com/metapolator/metapolator.git
+# Set and fetch upstream, or fetch and exit if already set
+git remote add -f upstream https://github.com/metapolator/metapolator.git || ( git fetch upstream; exit )
 
 # Alias for fetching pull requests from upstream, e.g.:
 # $ git checkout pr/165


### PR DESCRIPTION
This eases Vagrant provisioning, as the script can be run without
worrying about it erroring out if there’s already a metapolator
checkout.

Also remove recommendation of hub, that is already in the Vagrantfile.
