### PR TITLE
caching the requests to StyleDict.get

### DIFF
--- a/app/lib/models/CPS/StyleDict.js
+++ b/app/lib/models/CPS/StyleDict.js
@@ -1,9 +1,11 @@
 define([
     'metapolator/errors'
   , './cpsGetters'
+  , 'metapolator/memoize'
 ], function(
     errors
   , cpsGetters
+  , memoize
 ) {
     "use strict";
 
@@ -90,7 +92,7 @@ define([
      * is accessible or constructable from CPS formulae, or a white-listed
      * value on any reachable element.
      */
-    _p.get = function(name) {
+    _p._get = function(name) {
         var errors = [];
         if(name === 'this')
             return this._element;
@@ -132,6 +134,8 @@ define([
             delete this._getting[name];
         }
     }
+
+    _p.get = memoize('get', _p._get);
 
     return StyleDict;
 });


### PR DESCRIPTION
Note: models/Controller is already pruning these caches when
the CPS is updated, because it then deletes all StyleDict instances.
