### PR TITLE
Added some test font data for UFO component handling.

### DIFF
--- a/data/fonts/README.md
+++ b/data/fonts/README.md
@@ -5,3 +5,18 @@ directory will be placed into other directories depending on purpose.
 For example, a subset of the glyphs of Merriweather-Regular.otf might
 be saved into subsets/Merriweather-Regular-PAN.ufo to allow quicker
 tinkering using only the PAN glyphs or some other subset.
+
+The test/components.ufo font is for UFO component testing. It consists
+of three glyphs: a, b, and c. The c is drawn with a horizontal bar
+across the bottom of the glyph. The b has a bar across the middle of
+the glyph and a component reference to the c glyph (this b should be
+two horizontal bars). The a has a horizontal bar across the top of the
+glyph and a component reference to the 'b' glyph. Thus the 'a' glyph
+should be rendered as three horizontal lines. This allows testing not
+only single component references, but also recursive references.
+
+I also hand crafted test/circular-components.ufo to test bad font
+loading. The circular-components font is based on the above but having
+'c' referencing 'a' and thus creating a circular reference which is
+expressly not allowed by the UFO specification:
+http://unifiedfontobject.org/versions/ufo3/glif.html#component

--- a/data/fonts/test/circular-components.ufo/features.fea
+++ b/data/fonts/test/circular-components.ufo/features.fea
@@ -1,0 +1,9 @@
+
+
+@GDEF_Simple = [\c \b \a ];
+
+table GDEF {
+  GlyphClassDef @GDEF_Simple, , , ;
+
+} GDEF;
+

--- a/data/fonts/test/circular-components.ufo/fontinfo.plist
+++ b/data/fonts/test/circular-components.ufo/fontinfo.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>familyName</key>
+    <string>Untitled1</string>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>versionMajor</key>
+    <integer>1</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+    <key>copyright</key>
+    <string>Copyright (c) 2014, Ben Martin</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>italicAngle</key>
+    <real>0</real>
+    <key>note</key>
+    <string>2014-11-14: Created with FontForge (http://fontforge.org)</string>
+    <key>openTypeHeadCreated</key>
+    <string>2014/11/14 10:55:33</string>
+    <key>openTypeHheaAscender</key>
+    <integer>761</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>45</integer>
+    <key>openTypeHheaLineGap</key>
+    <integer>0</integer>
+    <key>openTypeNameVersion</key>
+    <string>Version 001.000</string>
+    <key>postscriptFontName</key>
+    <string>Untitled1</string>
+    <key>postscriptFullName</key>
+    <string>Untitled1</string>
+    <key>postscriptWeightName</key>
+    <string>Regular</string>
+    <key>postscriptUnderlineThickness</key>
+    <integer>50</integer>
+    <key>postscriptUnderlinePosition</key>
+    <integer>-100</integer>
+  </dict>
+</plist>

--- a/data/fonts/test/circular-components.ufo/glyphs/a.glif
+++ b/data/fonts/test/circular-components.ufo/glyphs/a.glif
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="a" format="1">
+  <advance width="1000"/>
+  <unicode hex="0061"/>
+  <outline>
+    <contour>
+      <point x="151" y="734" type="curve" smooth="yes"/>
+      <point x="103" y="728"/>
+      <point x="64" y="699"/>
+      <point x="59" y="650" type="curve" smooth="yes"/>
+      <point x="54" y="602"/>
+      <point x="86" y="557"/>
+      <point x="133" y="552" type="curve" smooth="yes"/>
+      <point x="420" y="520"/>
+      <point x="586" y="528"/>
+      <point x="873" y="558" type="curve" smooth="yes"/>
+      <point x="932" y="564"/>
+      <point x="1020" y="587"/>
+      <point x="1000" y="644" type="curve" smooth="yes"/>
+      <point x="972" y="724"/>
+      <point x="891" y="735"/>
+      <point x="807" y="744" type="curve" smooth="yes"/>
+      <point x="553" y="771"/>
+      <point x="405" y="766"/>
+    </contour>
+    <component base="b"/>
+  </outline>
+</glyph>

--- a/data/fonts/test/circular-components.ufo/glyphs/b.glif
+++ b/data/fonts/test/circular-components.ufo/glyphs/b.glif
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="b" format="1">
+  <advance width="1000"/>
+  <unicode hex="0062"/>
+  <outline>
+    <contour>
+      <point x="207" y="450" type="curve" smooth="yes"/>
+      <point x="137" y="442"/>
+      <point x="78" y="404"/>
+      <point x="69" y="334" type="curve" smooth="yes"/>
+      <point x="62" y="282"/>
+      <point x="131" y="267"/>
+      <point x="183" y="262" type="curve" smooth="yes"/>
+      <point x="444" y="235"/>
+      <point x="595" y="231"/>
+      <point x="857" y="252" type="curve" smooth="yes"/>
+      <point x="902" y="256"/>
+      <point x="958" y="278"/>
+      <point x="949" y="322" type="curve" smooth="yes"/>
+      <point x="937" y="383"/>
+      <point x="884" y="408"/>
+      <point x="823" y="418" type="curve" smooth="yes"/>
+      <point x="586" y="459"/>
+      <point x="446" y="477"/>
+    </contour>
+    <component base="c"/>
+  </outline>
+</glyph>

--- a/data/fonts/test/circular-components.ufo/glyphs/c.glif
+++ b/data/fonts/test/circular-components.ufo/glyphs/c.glif
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="c" format="1">
+  <advance width="1000"/>
+  <unicode hex="0063"/>
+  <outline>
+    <contour>
+      <point x="201" y="180" type="curve" smooth="yes"/>
+      <point x="150" y="178"/>
+      <point x="90" y="180"/>
+      <point x="81" y="130" type="curve" smooth="yes"/>
+      <point x="73" y="85"/>
+      <point x="136" y="74"/>
+      <point x="181" y="70" type="curve" smooth="yes"/>
+      <point x="451" y="44"/>
+      <point x="606" y="38"/>
+      <point x="877" y="54" type="curve" smooth="yes"/>
+      <point x="913" y="56"/>
+      <point x="959" y="79"/>
+      <point x="949" y="114" type="curve" smooth="yes"/>
+      <point x="936" y="156"/>
+      <point x="890" y="156"/>
+      <point x="845" y="160" type="curve" smooth="yes"/>
+      <point x="595" y="182"/>
+      <point x="452" y="190"/>
+    </contour>
+    <component base="a"/>
+  </outline>
+</glyph>

--- a/data/fonts/test/circular-components.ufo/glyphs/contents.plist
+++ b/data/fonts/test/circular-components.ufo/glyphs/contents.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>c</key>
+    <string>c.glif</string>
+    <key>b</key>
+    <string>b.glif</string>
+    <key>a</key>
+    <string>a.glif</string>
+  </dict>
+</plist>

--- a/data/fonts/test/circular-components.ufo/metainfo.plist
+++ b/data/fonts/test/circular-components.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>net.GitHub.FontForge</string>
+    <key>formatVersion</key>
+    <integer>2</integer>
+  </dict>
+</plist>

--- a/data/fonts/test/components.ufo/features.fea
+++ b/data/fonts/test/components.ufo/features.fea
@@ -1,0 +1,9 @@
+
+
+@GDEF_Simple = [\c \b \a ];
+
+table GDEF {
+  GlyphClassDef @GDEF_Simple, , , ;
+
+} GDEF;
+

--- a/data/fonts/test/components.ufo/fontinfo.plist
+++ b/data/fonts/test/components.ufo/fontinfo.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>familyName</key>
+    <string>Untitled1</string>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>versionMajor</key>
+    <integer>1</integer>
+    <key>versionMinor</key>
+    <integer>0</integer>
+    <key>copyright</key>
+    <string>Copyright (c) 2014, Ben Martin</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>italicAngle</key>
+    <real>0</real>
+    <key>note</key>
+    <string>2014-11-14: Created with FontForge (http://fontforge.org)</string>
+    <key>openTypeHeadCreated</key>
+    <string>2014/11/14 10:55:33</string>
+    <key>openTypeHheaAscender</key>
+    <integer>761</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>45</integer>
+    <key>openTypeHheaLineGap</key>
+    <integer>0</integer>
+    <key>openTypeNameVersion</key>
+    <string>Version 001.000</string>
+    <key>postscriptFontName</key>
+    <string>Untitled1</string>
+    <key>postscriptFullName</key>
+    <string>Untitled1</string>
+    <key>postscriptWeightName</key>
+    <string>Regular</string>
+    <key>postscriptUnderlineThickness</key>
+    <integer>50</integer>
+    <key>postscriptUnderlinePosition</key>
+    <integer>-100</integer>
+  </dict>
+</plist>

--- a/data/fonts/test/components.ufo/glyphs/a.glif
+++ b/data/fonts/test/components.ufo/glyphs/a.glif
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="a" format="1">
+  <advance width="1000"/>
+  <unicode hex="0061"/>
+  <outline>
+    <contour>
+      <point x="151" y="734" type="curve" smooth="yes"/>
+      <point x="103" y="728"/>
+      <point x="64" y="699"/>
+      <point x="59" y="650" type="curve" smooth="yes"/>
+      <point x="54" y="602"/>
+      <point x="86" y="557"/>
+      <point x="133" y="552" type="curve" smooth="yes"/>
+      <point x="420" y="520"/>
+      <point x="586" y="528"/>
+      <point x="873" y="558" type="curve" smooth="yes"/>
+      <point x="932" y="564"/>
+      <point x="1020" y="587"/>
+      <point x="1000" y="644" type="curve" smooth="yes"/>
+      <point x="972" y="724"/>
+      <point x="891" y="735"/>
+      <point x="807" y="744" type="curve" smooth="yes"/>
+      <point x="553" y="771"/>
+      <point x="405" y="766"/>
+    </contour>
+    <component base="b"/>
+  </outline>
+</glyph>

--- a/data/fonts/test/components.ufo/glyphs/b.glif
+++ b/data/fonts/test/components.ufo/glyphs/b.glif
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="b" format="1">
+  <advance width="1000"/>
+  <unicode hex="0062"/>
+  <outline>
+    <contour>
+      <point x="207" y="450" type="curve" smooth="yes"/>
+      <point x="137" y="442"/>
+      <point x="78" y="404"/>
+      <point x="69" y="334" type="curve" smooth="yes"/>
+      <point x="62" y="282"/>
+      <point x="131" y="267"/>
+      <point x="183" y="262" type="curve" smooth="yes"/>
+      <point x="444" y="235"/>
+      <point x="595" y="231"/>
+      <point x="857" y="252" type="curve" smooth="yes"/>
+      <point x="902" y="256"/>
+      <point x="958" y="278"/>
+      <point x="949" y="322" type="curve" smooth="yes"/>
+      <point x="937" y="383"/>
+      <point x="884" y="408"/>
+      <point x="823" y="418" type="curve" smooth="yes"/>
+      <point x="586" y="459"/>
+      <point x="446" y="477"/>
+    </contour>
+    <component base="c"/>
+  </outline>
+</glyph>

--- a/data/fonts/test/components.ufo/glyphs/c.glif
+++ b/data/fonts/test/components.ufo/glyphs/c.glif
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="c" format="1">
+  <advance width="1000"/>
+  <unicode hex="0063"/>
+  <outline>
+    <contour>
+      <point x="201" y="180" type="curve" smooth="yes"/>
+      <point x="150" y="178"/>
+      <point x="90" y="180"/>
+      <point x="81" y="130" type="curve" smooth="yes"/>
+      <point x="73" y="85"/>
+      <point x="136" y="74"/>
+      <point x="181" y="70" type="curve" smooth="yes"/>
+      <point x="451" y="44"/>
+      <point x="606" y="38"/>
+      <point x="877" y="54" type="curve" smooth="yes"/>
+      <point x="913" y="56"/>
+      <point x="959" y="79"/>
+      <point x="949" y="114" type="curve" smooth="yes"/>
+      <point x="936" y="156"/>
+      <point x="890" y="156"/>
+      <point x="845" y="160" type="curve" smooth="yes"/>
+      <point x="595" y="182"/>
+      <point x="452" y="190"/>
+    </contour>
+  </outline>
+</glyph>

--- a/data/fonts/test/components.ufo/glyphs/contents.plist
+++ b/data/fonts/test/components.ufo/glyphs/contents.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>c</key>
+    <string>c.glif</string>
+    <key>b</key>
+    <string>b.glif</string>
+    <key>a</key>
+    <string>a.glif</string>
+  </dict>
+</plist>

--- a/data/fonts/test/components.ufo/metainfo.plist
+++ b/data/fonts/test/components.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>net.GitHub.FontForge</string>
+    <key>formatVersion</key>
+    <integer>2</integer>
+  </dict>
+</plist>


### PR DESCRIPTION
Note that circular-components shouldn't be seen in the wild, but being able to
do something sane if we are presented with cirucular component
references might be useful. Even if that 'something sane' is to report
it in a meaningful way to the user.
