### PR TITLE
Swap order of fontbys

### DIFF
--- a/slider/js/controllers/specimenController.js
+++ b/slider/js/controllers/specimenController.js
@@ -26,7 +26,7 @@ app.controller('specimenController', ['$scope', '$sce', 'sharedScope', function(
     $scope.filter = "";
     $scope.strict = 1;
     $scope.fontbys = [
-        "glyph", "word"
+        "word", "glyph"
     ];
     $scope.selectedFontby = $scope.fontbys[0];
 


### PR DESCRIPTION
@jeroenbreen

Currently the metapolator slider prototype's default specimen view looks kind of crazy, incrementing the fonts by glyph:

![screen shot 2015-01-29 at 4 35 43 pm](https://cloud.githubusercontent.com/assets/261579/5966804/7258ed70-a7d5-11e4-9b48-f7ec3a96b94d.png)

Incrementing fonts by word looks less crazy:

![screen shot 2015-01-29 at 4 35 32 pm](https://cloud.githubusercontent.com/assets/261579/5966805/725c751c-a7d5-11e4-9056-7c2a1c82269c.png)

Thus, swap their order in their parental list JS object.