### PR TITLE
red-pill-demo/index.html: Add alert for non-firefox users

### DIFF
--- a/red-pill-demo/index.html
+++ b/red-pill-demo/index.html
@@ -21,12 +21,6 @@
         dumpLineNumbers: 'mediaquery',
         relativeUrls: false,
     };
-    function checkFirefox() {
-      if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1)
-      {
-        alert("This demo only works out of the box with the latest version of Firefox");
-      }
-    }
     </script>
     <script src="/lib/bower_components/less.js/dist/less-1.7.0.min.js"></script>
     <script src="/lib/bower_components/requirejs/require.js" data-main="/lib/redPillMain.js"></script>
@@ -34,6 +28,13 @@
     <!-- production -->
     <link rel="stylesheet" type="text/css" href="main.css" />
     <script src="main.js"></script>
+    <script>
+    function checkFirefox() {
+      if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+        alert("This demo only works out of the box with the latest version of Firefox\n\nIt can run with Chrome if you start it with \n\nchrome --js-flags=\"--harmony --harmony_proxies\"");
+      }
+    }
+    </script>
     <!-- end of production -->
   </head>
   <body onload="checkFirefox()">

--- a/red-pill-demo/index.html
+++ b/red-pill-demo/index.html
@@ -21,6 +21,12 @@
         dumpLineNumbers: 'mediaquery',
         relativeUrls: false,
     };
+    function checkFirefox() {
+      if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1)
+      {
+        alert("This demo only works out of the box with the latest version of Firefox");
+      }
+    }
     </script>
     <script src="/lib/bower_components/less.js/dist/less-1.7.0.min.js"></script>
     <script src="/lib/bower_components/requirejs/require.js" data-main="/lib/redPillMain.js"></script>
@@ -30,7 +36,7 @@
     <script src="main.js"></script>
     <!-- end of production -->
   </head>
-  <body>
+  <body onload="checkFirefox()">
     <h1>Metapolator Neue</h1>
     <h3>The Red Pill Interface</h3>
     <red-pill></red-pill>


### PR DESCRIPTION
When visiting red pill demo in anything other than latest firefox, nothing appears, which is frustrating. 

So let non-firefox users know they should get the latest FF :)