### PR TITLE
Removing unused code from GlyphRendererAPI.js (EnhancedSVGPen)

### DIFF
--- a/app/lib/ui/services/GlyphRendererAPI.js
+++ b/app/lib/ui/services/GlyphRendererAPI.js
@@ -23,25 +23,6 @@ define([
       , draw = ExportController.drawGlyphToPointPen
       ;
 
-    function EnhancedSVGPen(data, glyphRendererAPI, path, glyphSet) {
-        SVGPen.call(this, path, glyphSet);
-        this._data = data;
-        this._glyphRendererAPI = glyphRendererAPI;
-    }
-    var _pp = EnhancedSVGPen.prototype = Object.create(SVGPen.prototype);
-    _pp.constructor = EnhancedSVGPen;
-
-    _pp.addComponent = function(glyphName, transformation, kwargs /*optional, object*/) {
-        var data = this._data
-          , masterName = data.MOM.master.name
-          , use = this._glyphRendererAPI.get(masterName, glyphName, 'use')
-          , key = this._glyphRendererAPI.getKey(masterName, glyphName)
-          ;
-        use.setAttribute('transform', 'matrix(' +  transformation.join(',') + ')');
-        data.components.push(key);
-        data.svg.appendChild(use);
-    };
-
     function GlyphRendererAPI(document, controller) {
         this._doc = document;
         this._controller = controller;


### PR DESCRIPTION
I may be wrong here, but it seems to me that the definition of EnhancedSVGPen is pointless at app/lib/ui/services/GlyphRendererAPI.js as there's no other use of this object anywhere else in the codebase.

This may be some leftover code that still needs to be refactored out (i.e. deleted).