### PR TITLE
Blue pill bootstrap

### DIFF
--- a/app/lib/Metapolator.js
+++ b/app/lib/Metapolator.js
@@ -1,9 +1,30 @@
-define([], function() {
+define([
+    'webAPI/document'
+  , 'metapolator/models/metapolator/AppModel'
+  , 'metapolator/ui/services/GlyphRendererAPI'
+], function(
+    document
+  , AppModel
+  , GlyphRendererAPI
+) {
     "use strict";
-    function Metapolator(model, angularApp) {
+    function Metapolator(project, angularApp) {
         this.angularApp = angularApp;
         this.frontend = undefined;
-        this.model = model;
+        this.model = this._modelFactory();
+        this.project = project;
+
+        // load all masters, because right now it is very confusing
+        // when some masters are missing from the MOM
+        this.project.masters.forEach(this.project.open, this.project);
+
+        this.glyphRendererAPI = new GlyphRendererAPI(document, project.controller);
+        // FIXME: this is the MOM/CPS model, rename? The name is inherited
+        // from the Red Pill, but since we are going to have more models this
+        // could get a more distinct name. Should be renamed in the Red Pill as
+        // well, if we do so.
+        this.angularApp.constant('ModelController', this.project.controller);
+        this.angularApp.constant('glyphRendererAPI', this.glyphRendererAPI);
 
         // will be called on angular.bootstrap
         // see ui/app-controller.js
@@ -15,8 +36,33 @@ define([], function() {
 
     _p._registerFrontend = function(appController) {
         if (this.frontend !== undefined)
-            throw new Error('Registering more than one AppController is not allowed.' + ' Don\'t use <metapolator> more than once in a template!');
+            throw new Error('Registering more than one AppController is not allowed.'
+                           + ' Don\'t use <metapolator> more than once in a template!');
         this.frontend = appController;
+    };
+
+    // probably this should be replaced by sth. like `new AppModel(data);`
+    _p._modelFactory = function() {
+        var model = new AppModel();
+        // set initial model data
+        // FIXME: this stuff too much hardcoding, we need a saner way to do this things
+        model.masterPanel.addSequence("Sequence 1");
+        model.instancePanel.addSequence("Family 1");
+        // creation of inital masters
+        var masters = ["Regular", "Bold", "Light", "Condensed", "Extended", "Italic"];
+        var glyphs = ["A", "B", "C", "D", "E", "F", "G", "H", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "space"];
+        masters.forEach(function(master) {
+            // this = model.masterPanel.sequences[0]
+            this.addMaster(master);
+            glyphs.forEach(function(glyph) {
+                // this = model.masterPanel.sequences[0]
+                var masterIndex = this.children.length - 1;
+                this.children[masterIndex].addGlyph(glyph);
+            }, this);
+        }, model.masterPanel.sequences[0]);
+        model.designSpacePanel.addDesignSpace();
+        model.designSpacePanel.currentDesignSpace = model.designSpacePanel.designSpaces[0];
+        return model;
     };
 
     return Metapolator;

--- a/app/lib/Metapolator.js
+++ b/app/lib/Metapolator.js
@@ -23,7 +23,8 @@ define([
         // from the Red Pill, but since we are going to have more models this
         // could get a more distinct name. Should be renamed in the Red Pill as
         // well, if we do so.
-        this.angularApp.constant('ModelController', this.project.controller);
+        this.angularApp.constant('modelController', this.project.controller);
+        this.angularApp.constant('project', this.project);
         this.angularApp.constant('glyphRendererAPI', this.glyphRendererAPI);
 
         // will be called on angular.bootstrap

--- a/app/lib/browserConfig.js
+++ b/app/lib/browserConfig.js
@@ -1,5 +1,5 @@
 requirejs.config({
-    baseUrl: '../'
+    baseUrl: 'lib'
   , paths: {
         'require/domReady': 'bower_components/requirejs-domready/domReady'
       , 'require/text': 'bower_components/requirejs-text/text'

--- a/app/lib/html/metapolator.html
+++ b/app/lib/html/metapolator.html
@@ -12,7 +12,7 @@
         <!-- less
 
         for development only and will disappear in production -->
-        <link rel="stylesheet/less" type="text/css" href="../ui/metapolator/app.less" />
+        <link rel="stylesheet/less" type="text/css" href="lib/ui/metapolator/app.less" />
 
         <script>
             less = {
@@ -26,14 +26,14 @@
             };
         </script>
 
-            
-        <script src="../bower_components/less.js/dist/less-1.7.0.min.js"></script>
+
+        <script src="lib/bower_components/less.js/dist/less-1.7.0.min.js"></script>
         <!-- end of less -->
 
-        <script src="../bower_components/requirejs/require.js"></script>
+        <script src="lib/bower_components/requirejs/require.js"></script>
         <script>
-        require(['../browserConfig.js'], function(){
-            require(['../metapolatorMain.js']);
+        require(['lib/browserConfig.js'], function(){
+            require(['lib/metapolatorMain.js']);
         });
         </script>
     </head>

--- a/app/lib/metapolatorStandAlone.js
+++ b/app/lib/metapolatorStandAlone.js
@@ -48,33 +48,6 @@ function (
         setTimeout(callback, 0, exports);
     }
 
-    /**
-     * FIXME: this should be part of app/lib/project/MetapolatorProject
-     * probably. I copy and pasted it from app/lib/RedPill
-     *
-     * this === project
-     */
-    function fileChangeHandler(path) {
-        /*jshint validthis: true*/
-        var match = path.indexOf(this.cpsDir)
-          , sourceName
-          ;
-        if(match !== 0)
-            return;
-        // +1 to remove the leading slash
-        sourceName = path.slice(this.cpsDir.length + 1);
-        try {
-            this.controller.updateChangedRule(true, sourceName);
-        }
-        catch(error) {
-            // KeyError will be thrown by RuleController.replaceRule if
-            // sourceName is unknown, which is expected at this point,
-            // because that means that sourceName is unused.
-            if(!(error instanceof errors.Key))
-                throw error;
-        }
-    }
-
     // This pattern is used by google analytics, for example, to execute
     // api calls "before" the api is available. The calling code does:
     // if(!window.metapolatorReady)
@@ -99,9 +72,8 @@ function (
 
         return promise.then(function() {
             var project, glyphRendererAPI;
-            project = new MetapolatorProject(io, 'project');
+            project = new MetapolatorProject(io, 'project', fsEvents);
             project.load();
-            fsEvents.on('change', fileChangeHandler.bind(project));
             // load all masters, because right now it is very confusing
             // when some masters are missing from the MOM
             project.masters.forEach(project.open, project);

--- a/app/lib/models/metapolator/AppModel.js
+++ b/app/lib/models/metapolator/AppModel.js
@@ -4,7 +4,7 @@ define([
  , './masterPanel/MasterPanelModel'
  , './designSpacePanel/DesignSpacePanelModel'
  , './instancePanel/InstancePanelModel'
- , './DisplayModel/DisplayModel'
+ , './displayModel/DisplayModel'
 ], function(
     Parent
   , SpecimenModel
@@ -26,12 +26,12 @@ define([
         this.display = new DisplayModel();
      }
     var _p = AppModel.prototype = Object.create(Parent.prototype);
-    
+
     _p.addSequence = function(name) {
         this.sequences.push(
             new SequenceModel(name)
         );
     };
-    
+
     return AppModel;
 });

--- a/app/lib/models/metapolator/masterPanel/MasterPanelModel.js
+++ b/app/lib/models/metapolator/masterPanel/MasterPanelModel.js
@@ -1,11 +1,9 @@
 define([
     '../_BaseModel'
-  , '../Appmodel'
   , './SequenceModel'
-  , './selectionModel/selectionModel'
+  , './selectionModel/SelectionModel'
 ], function(
     Parent
-  , Appmodel
   , SequenceModel
   , SelectionModel
 ){
@@ -17,7 +15,7 @@ define([
         this.stackedParameters = [];
         /*
          // until #392 is fixed, we work only with width and weight
-    
+
          this.baseParameters = [{
          name : "Weight",
          cpsKey : "WeightF",
@@ -105,15 +103,15 @@ define([
             effectiveLocal : false
         }];
     }
-        
+
     var _p = MasterPanelModel.prototype = Object.create(Parent.prototype);
-    
+
     _p.addStackedParameter = function(parameter) {
         if (this.stackedParameters.indexOf(parameter) == -1) {
             this.stackedParameters.push(parameter);
         }
     };
-    
+
     _p.updateSelections = function(updatedLevel) {
         window.logCall("updateSelections");
         this.destackOperators();
@@ -124,7 +122,7 @@ define([
             var level = this.allLevels[i];
             if (level == updatedLevel) {
                 beyond = true;
-            }   
+            }
             if (beyond) {
                 this.selection[level].updateThisSelection(parentEmpty);
             }
@@ -132,9 +130,9 @@ define([
                 // if this level is empty, then deeper levels are empty automatically
                 parentEmpty = true;
             }
-        }       
+        }
     };
-    
+
     _p.destackOperators = function() {
         window.logCall("destackOperators");
         var elements = this.stackedParameters;
@@ -145,14 +143,14 @@ define([
         // after destacking, empty the list
         this.stackedParameters = [];
     };
-    
+
     _p.addSelectionLevel = function(level) {
         window.logCall("addSelectionLevel");
         this.selection[level] = new SelectionModel(
             level, this.baseParameters, this.baseOperators, this.sequences, this.allLevels, this
         );
     };
-    
+
     _p.addSequence = function(name) {
         window.logCall("addSequence");
         this.sequences.push(
@@ -161,19 +159,19 @@ define([
             )
         );
     };
-    
+
     _p.areChildrenSelected = function () {
         for (var i = this.sequences.length - 1; i >= 0; i--) {
             var sequence = this.sequences[i];
             for (var j = sequence.children.length - 1; j >= 0; j--) {
                 var master = sequence.children[j];
                 if (master.edit[0]) {
-                    return true;    
+                    return true;
                 }
             }
-        }   
+        }
         return false;
     };
-    
+
     return MasterPanelModel;
 });

--- a/app/lib/redPillMain.js
+++ b/app/lib/redPillMain.js
@@ -62,11 +62,10 @@ function (
     document.body.classList.add('dependencies-ready');
     function main() {
         var io = setup.io
-          , fsEvents = setup.fsEvents
-          , project = new MetapolatorProject(io, 'project')
+          , project = new MetapolatorProject(io, 'project', setup.fsEvents)
           ;
         project.load();
-        new RedPill(io, fsEvents, project, angularApp, setup.loadTextEditor);
+        new RedPill(io, project, angularApp, setup.loadTextEditor);
         // this should be the last thing here, because domReady will execute
         // immediately if the DOM is already ready.
         domReady(function() {

--- a/app/lib/ui/metapolator/cpsAPITools.js
+++ b/app/lib/ui/metapolator/cpsAPITools.js
@@ -1,0 +1,84 @@
+require([
+  , 'metapolator/errors'
+  , 'metapolator/project/parameters/registry'
+  , 'metapolator/models/CPS/elements/ParameterValue'
+  , 'metapolator/models/CPS/elements/Parameter'
+  , 'metapolator/models/CPS/elements/ParameterDict'
+  , 'metapolator/models/CPS/elements/Rule'
+  , 'metapolator/models/CPS/elements/AtImportCollection'
+  , 'metapolator/models/CPS/parsing/parseSelectorList'
+],
+function (
+  , errors
+  , parameterRegistry
+  , ParameterValue
+  , Parameter
+  , ParameterDict
+  , Rule
+  , AtImportCollection
+  , parseSelectorList
+) {
+    "use strict";
+    // TODO: let this grow into a useful collection of tools, then make
+    // a module out of it.
+    // It's hard to know in advance what's going to be needed
+    return {
+        /**
+         * Set `value` to the parameter `name` of `parameterDict`.
+         *
+         * Arguments:
+         * parameterDict: an instance of ParameterDict as returned
+         *                by Rule.parameters
+         * name: a string with the parameter name
+         * value: a string (of cps-formulae-language¹)
+         *
+         * return value: nothing.
+         * raises: potentially a lot.
+         *
+         * ¹ Actually this depends on which type is registered for `name`
+         *   but at the time of this writing there is only cps-formulae-language.
+         *   There are, however, parameters that check their return type,
+         *   after evaluation of the cps-formulae-language.
+         */
+        setParameter: function setParameter(parameterDict, name, value) {
+            var _value = new ParameterValue([value], [])
+                , parameter
+                , factory = parameterRegistry.getFactory(name)
+                ;
+            _value.initializeTypeFactory(name, factory);
+            parameter = new Parameter({name:name}, _value);
+            parameterDict.setParameter(parameter);
+        }
+      , addNewRule: function addNewRule(parameterCollection, index, selectorListString) {
+            var source = 'generated'
+              , selectorList = parseSelectorList.fromString(selectorListString)
+              , parameterDict = new ParameterDict([], source, 0)
+              , rule = new Rule(selectorList, parameterDict, source, 0)
+              ;
+            // returns the actual index at which the rule was created
+            return parameterCollection.splice(index, 0, rule)[0];
+        }
+        /**
+         * CAUTION: Here an intersting dependency to ruleController emerges.
+         * Probably this method should be part of the stateful interface,
+         * because this way a ruleController from a different project can
+         * be used which is not intended right now and was never tested!
+         */
+      , addNewAtImport: function addNewAtImport(async, parameterCollection
+                                    , index, ruleController, resourceName) {
+            var collection = new AtImportCollection(ruleController, 'generated')
+                // it's only a promise if `async` is true
+              , promise = collection.setResource(async, resourceName)
+              ;
+
+            function resolve() {
+                return parameterCollection.splice(index, 0, collection)[0];
+            }
+
+            return async
+                 ? promise.then(resolve, errors.unhandledPromise)
+                 : resolve()
+                 ;
+        }
+    };
+});

--- a/app/lib/ui/metapolator/dialog/dialog.tpl
+++ b/app/lib/ui/metapolator/dialog/dialog.tpl
@@ -1,7 +1,7 @@
 <div id="layover">
     <div id="dialog">
         <div id="dialog-close" ng-click="model.closeDialogScreen()">×</div>
-        <div id="dialog-loading"><img src="../ui/metapolator/assets/img/loading.gif"></div>
+        <div id="dialog-loading"><img src="lib/ui/metapolator/assets/img/loading.gif"></div>
         <div id="dialog-content"></div>
         <div id="dialog-confirm">
             <button id="dialog-button-true" ng-click="">Okay</button>

--- a/app/lib/ui/metapolator/instance-panel/instance-panel.tpl
+++ b/app/lib/ui/metapolator/instance-panel/instance-panel.tpl
@@ -17,12 +17,12 @@
         <ul class="ul-sequence">
             <li class="li-sequence" ng-repeat="sequence in model.sequences">
                 <ul class="ul-master" ui-sortable="sortableOptions" ng-model="sequence.children">
-                    <li class="li-master" 
+                    <li class="li-master"
                         ng-repeat="instance in sequence.children"
                         ng-mouseover="mouseoverInstance(instance)"
                         ng-mouseleave="mouseleaveInstance()">
-                        <mtk-instance class="mtk-master" 
-                                      mtk-model="instance" 
+                        <mtk-instance class="mtk-master"
+                                      mtk-model="instance"
                                       ng-class="{'selected': instance == model.currentInstance}"></mtk-instance>
                     </li>
                 </ul>
@@ -31,16 +31,16 @@
                 {{axis.master.displayName}} - {{axis.axisValue}} - {{axis.metapolationValue.toFixed(2)}}
             </div>
         </ul>
-        
+
         <div class="list-buttons">
             <div title="Add Instance" ng-click="addInstance();" class="list-button">
-                <img src="../ui/metapolator/assets/img/addInstance.png" ng-class="{'inactive': !canAddInstance()}">
+                <img src="lib/ui/metapolator/assets/img/addInstance.png" ng-class="{'inactive': !canAddInstance()}">
             </div>
             <div title="Duplicate Instance" ng-click="duplicateInstance(model.currentInstance);" class="list-button">
-                <img src="../ui/metapolator/assets/img/duplicateInstance.png" ng-class="{'inactive': !model.currentInstance}">
+                <img src="lib/ui/metapolator/assets/img/duplicateInstance.png" ng-class="{'inactive': !model.currentInstance}">
             </div>
             <div title="Delete" ng-click="deleteInstance(model.currentInstance);" class="list-button">
-                <img src="../ui/metapolator/assets/img/deleteInstance.png" ng-class="{'inactive': !model.currentInstance}">
+                <img src="lib/ui/metapolator/assets/img/deleteInstance.png" ng-class="{'inactive': !model.currentInstance}">
             </div>
             <div class="list-button export-button" ng-click="exportFonts()" ng-class="{'inactive': !instancesForExport() || export_is_running}">
                 Export…

--- a/app/lib/ui/metapolator/master-panel/master-panel.tpl
+++ b/app/lib/ui/metapolator/master-panel/master-panel.tpl
@@ -15,12 +15,12 @@
     <ul class="ul-sequence">
         <li class="li-sequence" ng-repeat="sequence in model.sequences">
             <ul class="ul-master" ui-sortable="sortableOptions" ng-model="sequence.children">
-                <li class="li-master" 
+                <li class="li-master"
                     ng-repeat="master in sequence.children"
                     ng-mouseover="mouseoverMaster(master)"
                     ng-mouseleave="mouseleaveMaster()">
-                    <mtk-master class="mtk-master" 
-                                mtk-model="master" 
+                    <mtk-master class="mtk-master"
+                                mtk-model="master"
                                 ng-class="{'selected': master.edit[0]}"></mtk-master>
                 </li>
             </ul>
@@ -28,10 +28,10 @@
     </ul>
     <div class="list-buttons">
         <div title="Import UFO" ng-click="importUfo();" class="list-button">
-            <img src="../ui/metapolator/assets/img/importUfo.png">
+            <img src="lib/ui/metapolator/assets/img/importUfo.png">
         </div>
         <div title="Duplicate Master(s)" ng-click="duplicateMasters();" class="list-button">
-            <img src="../ui/metapolator/assets/img/duplicateMaster.png" ng-class="{'inactive': !model.areChildrenSelected()}">
+            <img src="lib/ui/metapolator/assets/img/duplicateMaster.png" ng-class="{'inactive': !model.areChildrenSelected()}">
         </div>
     </div>
 </div>

--- a/app/lib/ui/metapolator/specimen-panel/specimen-tools/line-height/line-height.tpl
+++ b/app/lib/ui/metapolator/specimen-panel/specimen-tools/line-height/line-height.tpl
@@ -1,7 +1,7 @@
 <mtk-local-menu class="localmenu lm-align-left">
     <div class="lm-head" ng-mousedown="localMenuCtrl.toggleMenu('lineHeight')">
         <div ng-if="model.lineHeightSetting != -1" class="lm-head-container">
-            <img ng-src="../ui/metapolator/assets/img/{{options[model.lineHeightSetting].img}}" title="Amount of line spacing (leading) in em">
+            <img ng-src="lib/ui/metapolator/assets/img/{{options[model.lineHeightSetting].img}}" title="Amount of line spacing (leading) in em">
         </div>
         <div ng-if="model.lineHeightSetting == -1" class="lm-head-container">
             / <input class="lineheight-custom" ng-model="model.lineHeight" ng-focus="updateLineHeightCustom('blur')" ng-keyup="updateLineHeightCustom($event)">

--- a/bin/metapolator-serve
+++ b/bin/metapolator-serve
@@ -4,7 +4,7 @@ __hash_bang_trick=/* exec /usr/bin/env node --harmony "$0" "$@"  # -*- mode: jav
 "use strict";
 
 exports.command = {
-    description: 'Open a UFO (default: current directory) in the red-pill web interface'
+    description: 'Serve a metapolator application loading a metapoltor project UFO (default: current directory).'
   , arguments: '[ufo]'
 };
 
@@ -18,6 +18,7 @@ if (require.main === module) {
     requirejs([
         'commander'
       , 'metapolator/parseArgs'
+      , 'metapolator/errors'
       , 'ufojs/tools/io/staticNodeJS'
       , 'restfs'
       , 'socket.io'
@@ -25,11 +26,25 @@ if (require.main === module) {
     ], function (
         program
       , parseArgs
+      , errors
       , io
       , restfs
       , SocketIO
       , fsEventsServer
     ) {
+        var CommandLineError = errors.CommandLine
+          , applications = {
+                'red-pill': {
+                    index: 'red-pill.html'
+                  , name: 'the Red Pill'
+                }
+              , 'metapolator': {
+                    index: 'metapolator.html'
+                  , name: 'the Blue Pill'
+                }
+            }
+          ;
+
         function mountAndMonitorRESTDirectory(location, baseDir, socketIO, app) {
             var relativeLocation = location[0] === '/'
                     ? location.slice(1)
@@ -47,6 +62,14 @@ if (require.main === module) {
             return program.port;
         }
 
+        function getApplication(key) {
+            if(key === undefined)
+                key = 'metapolator';
+            if(!(key in applications))
+                throw new CommandLineError('"'+key+'" is no known application.');
+            return applications[key];
+        }
+
         program._name = path.basename(process.argv[1]).replace('-', ' ');
         program.arguments(exports.command.arguments)
         .description(exports.command.description)
@@ -54,9 +77,10 @@ if (require.main === module) {
             // expect require.main.filename to be path/to/metapolator-code/bin/<command>
             // thus path/to/metapolator-code is the root directory
             var rootDir = path.dirname(path.dirname(require.main.filename))
+              , application = getApplication(program.application)
               , libDir = rootDir + '/app/lib'
               , htmlDir = rootDir + '/app/lib/html'
-              , index = htmlDir + '/red-pill.html'
+              , index = htmlDir + '/' + application.index
               , project = parseArgs.project(io, projectDir)
               , app = express()
               , server = app.listen(getPort(program))
@@ -80,12 +104,14 @@ if (require.main === module) {
                                                         , socketIO, app);
 
             if (server.address()) {
-                console.warn('Metapolator: Serving the red pill.');
+                console.warn('Metapolator: Serving ' + application.name + '.');
                 console.warn('Open http://localhost:'+server.address().port+' in your browser.');
                 console.warn('If you are using Chromium (or Chrome), you should run it as: chromium --js-flags="--harmony_proxies"');
             }
         })
-        .option('-p, --port <n>', 'The port to listen on (default: environment variable RED_PILL_PORT (if unset, random))', parseInt);
+        .option('-a, --application <'+(Object.keys(applications).join('|'))+'>', 'The main application to serve at index.html (default: metapolator)')
+        .option('-p, --port <n>', 'The port to listen on (default: environment variable RED_PILL_PORT (if unset, random))', parseInt)
+        ;
         program.parse(process.argv);
     }
 )}


### PR DESCRIPTION
@jeroenbreen in #624
> Though I could really need advice on the very first plug of the engine connecting.


This connects and starts the "engine"

To serve it you do for example:

```sh
$ metapolator serve ./your/project.mp -p 8080
```

We don't build this yet into a version that runs from a simple http file server, but we can add building it soon. It's not much to do. You should work on the code while the above server is running and refresh by reloading in the browser. I changed some addresses back to `lib/something` where you used `../something` the server reorganizes the file-structure a bit for the browser.

For your further refactoring this is how you can get the old methods back:

### everything that was in `stateful`

is now an AngularJs-Service, that you can `$inject` like this:

```js
function MyController(project, glyphRendererAPI, controller) {
     // `project` is the same as `stateful.project` was
     // `glyphRendererAPI` is the same as `stateful.glyphRendererAPI` was
     // `controller` is the same as `stateful.controller` was
}

MyController.$inject = ['project', 'glyphRendererAPI', 'modelController']
```

### everything that was in `stateless`

(except `stateless.initProject` that is no more.)

Is now a module that can be required:

```js
define([
    'metapolator/ui/metapolator/cpsAPITools'
  , 'metapolator/project/cps-generators/interpolation'
  , 'metapolator/project/cps-generators/metapolation'
  , 'filesaver'
  , 'jszip'
], function(
    cpsAPITools // former stateless.cpsAPITools
  , cpsGenInterpolation // former stateless.cpsGenerators.interpolation
  , cpsGenMetapolation // former stateless.cpsGenerators.metapolation
  , saveAs // former stateless.saveAs
  , JSZip // former stateless.JSZip
) {
 // ...
});
```

    

