### PR TITLE
Checking the index was the wrong way around (fixes #593)

### DIFF
--- a/app/lib/models/CPS/StyleDict.js
+++ b/app/lib/models/CPS/StyleDict.js
@@ -503,10 +503,10 @@ define([
                     : undefined
           ;
 
-        if(parametersIndexForKey > index)
-            // the higher index overrides the lower index
+        if(parametersIndexForKey < index)
+            // the lower index overrides the higher index
             return;
-        else if(parametersIndexForKey < index) {
+        else if(parametersIndexForKey > index) {
             this._unsetDictValue(key);
             this._invalidateCache(key);
         }


### PR DESCRIPTION
@jeroenbreen please check and reopen the bug if the issue is still present.

NOTE: I also found another bug, but I think that is not effective for the
blue pill. right now: Namespaces loose their influence when in "unrelated"
namespaces rules are moved. I have a better description here, but now time
to type left :-) Since you don't move stuff right now I hope that will
not effect you to soon. I'll have to fix it for the new red-pill cps-panel.