### PR TITLE
Fix of #633: Check if all glyphs are measured and cps is written before export 

### DIFF
--- a/app/lib/models/metapolator/instances/GlyphModel.js
+++ b/app/lib/models/metapolator/instances/GlyphModel.js
@@ -24,6 +24,8 @@ define([
         return this.parent.name;
     };
 
+    // this returns the glyphs - from the master this instance is based upon -
+    // with the same name as this glyph
     _p.getMasterGlyphs = function(glyphName) {
         var glyphs = [];
         for (var i = this.parent.axes.length - 1; i >= 0; i--) {

--- a/app/lib/models/metapolator/instances/GlyphModel.js
+++ b/app/lib/models/metapolator/instances/GlyphModel.js
@@ -23,6 +23,16 @@ define([
     _p.getMasterName = function() {
         return this.parent.name;
     };
+
+    _p.getMasterGlyphs = function(glyphName) {
+        var glyphs = [];
+        for (var i = this.parent.axes.length - 1; i >= 0; i--) {
+            var axis =  this.parent.axes[i]
+              , master = axis.master;
+            glyphs.push(master.findGlyphByName(this.name));
+        }
+        return glyphs;
+    };
     
     
     return GlyphModel;

--- a/app/lib/models/metapolator/masters/GlyphModel.js
+++ b/app/lib/models/metapolator/masters/GlyphModel.js
@@ -47,14 +47,19 @@ define([
 
     _p.checkIfIsDisplayed = function() {
         if (!this.displayed) {
+            // if a glyph is never displayed before it can have been measured
+            // (because measure info is shared among cloned masters)
             if (!this._isMeasured()) {
                 this._measureGlyph();
             }
+            // if this is the first display, it possibly needs to catch up
+            // on its cps (when its master has non-local operators (like plus and mines)
             this._catchUpCPS();
         }
     };
 
     _p._isMeasured = function() {
+        // find the original master (cloned masters shared this info with each other)
         var glyph = this._getOriginalGlyph();
         return glyph.measured;
     };
@@ -102,6 +107,7 @@ define([
                 for (var j = 0, jl = effectedElements.length; j < jl; j++) {
                     var effectedElement = effectedElements[j]
                         , elementParameter = effectedElement.getParameterByName(parameter.base.name);
+                    // update the effective value + the true argument means its going to write cps
                     elementParameter.updateEffectiveValue(true);
                 }
             }

--- a/app/lib/models/metapolator/masters/MasterModel.js
+++ b/app/lib/models/metapolator/masters/MasterModel.js
@@ -17,6 +17,7 @@ define([
         this.edit = true;
         this.ag = "Ag";
         this.parent = parent;
+        this.originalMaster = this;
         this.children = [];
 
         // cps properties

--- a/app/lib/models/metapolator/masters/ParameterModel.js
+++ b/app/lib/models/metapolator/masters/ParameterModel.js
@@ -74,6 +74,16 @@ define([
             return this.addOperator(changedOperator.base, id, level);
         }
     };
+
+    _p.checkIfHasNonLocalOperators = function() {
+        for (var i = 0, l = this.operators.length; i < l; i++) {
+            var operator = this.operators[i];
+            if (!operator.base.effectiveLocal) {
+                return true;
+            }
+        }
+        return false;
+    };
     
     _p.addOperator = function(baseOperator, id, level) {
         var operator = new OperatorModel(baseOperator, id, this);
@@ -97,7 +107,6 @@ define([
             for (var i = self.operators.length - 1; i >= 0; i--) {
                 var thisOperator = self.operators[i].name;
                 if (tempArray.indexOf(thisOperator) > -1) {
-                    console.log('!');
                     return true;
                 }
                 tempArray.push(thisOperator);

--- a/app/lib/models/metapolator/masters/_ElementModel.js
+++ b/app/lib/models/metapolator/masters/_ElementModel.js
@@ -28,7 +28,7 @@ function(
 
     _p.writeValueInCPSfile = function(factor, parameter) {
         var parameterCollection
-          , cpsRule;
+            , cpsRule;
         // && prevent removing hardcoded cps rule
         if (factor === 1 && this.level !== 'master') {
             this._removeParameter(parameter);
@@ -39,7 +39,7 @@ function(
             parameterCollection = this.master._project.ruleController.getRule(false, this.master.cpsFile);
             cpsRule = parameterCollection.getItem(this.ruleIndex);
             var parameterDict = cpsRule.parameters
-              , setParameter = cpsAPITools.setParameter;
+                , setParameter = cpsAPITools.setParameter;
             setParameter(parameterDict, parameter.base.cpsKey, factor);
             //console.log(cpsRule.toString());
         }
@@ -52,8 +52,8 @@ function(
             // if the factor equals 1 and the element already has an index, that means the cps rule is unnecessary
             // so we remove the property in the rule
             var parameterCollection = this.master._project.ruleController.getRule(false, this.master.cpsFile)
-              , ruleIndex = this.ruleIndex
-              , cpsRule = parameterCollection.getItem(ruleIndex);
+                , ruleIndex = this.ruleIndex
+                , cpsRule = parameterCollection.getItem(ruleIndex);
             cpsRule.parameters.erase(parameter.base.cpsKey);
             // if this is the last property in the rule, we remove the rule itself
             // therefor we have to rewrite all the rule indexes of this master
@@ -151,7 +151,7 @@ function(
     // cps functions
     _p.updateEffectiveValue = function(baseParameter, writeCPS) {
         var elementParameter = this.getParameterByName(baseParameter.name);
-        elementParameter.updateEffectiveValue(writeCPS);  
+        elementParameter.updateEffectiveValue(writeCPS);
     };
     
     _p.findParentsFactor = function(baseParameter) {
@@ -185,8 +185,8 @@ function(
                 var thisLevelElement = thisLevelElements[i];
                 for (var j = 0, jl = thisLevelElement.children.length; j < jl; j++) {
                     var childElement = thisLevelElement.children[j];
-                    // skip the unmeasured glyphs
-                    if (childElement.level !== 'glyph' || childElement.measured) {
+                    // skip the not yet ever displayed glyphs
+                    if (childElement.level !== 'glyph' || childElement.displayed) {
                         tempArray.push(childElement);
                     }
                 }

--- a/app/lib/models/metapolator/masters/_ElementModel.js
+++ b/app/lib/models/metapolator/masters/_ElementModel.js
@@ -221,6 +221,14 @@ function(
                 child.setMaster(master);
             }
         }
+        // restore the links to the master and to the element in the cloned parameters
+        if (this.parameters) {
+            for (var j = 0, jl = this.parameters.length; j < jl; j++) {
+                var parameter = this.parameters[j];
+                parameter.master = master;
+                parameter.element = this;
+            }
+        }
     };
 
     _p._cloneProperties = function(clone) {

--- a/app/lib/ui/metapolator/design-space-panel/control/control-directive-old.js
+++ b/app/lib/ui/metapolator/design-space-panel/control/control-directive-old.js
@@ -82,27 +82,27 @@ define([
                     buildData();
                     removeAll();
                     starttime = Date.now();
-                    console.log("start: " + starttime);
                     drawAll();
-                    console.log("end: " + (Date.now() - starttime));
                 }
                 
                 function buildData() {
-                    var nrOfInstances = 0;
+                    var nrOfInstances = 0
+                      , current
+                      , thisSlack;
                     designSpace = scope.model;
                     for (var i = scope.instancePanel.sequences.length - 1; i >= 0; i--) {
                         var sequence = scope.instancePanel.sequences[i];
                         for (var j = 0, jl = sequence.children.length; j < jl; j++) {
                             var instance = sequence.children[j];
                             if (instance == scope.instancePanel.currentInstance) {
-                                var current = true;
+                                current = true;
                             } else {
-                                var current = false;
+                                current = false;
                             }
-                            if (j == designSpace.slack) {
-                                var thisSlack = true;
+                            if (j === designSpace.slack) {
+                                thisSlack = true;
                             } else {
-                                var thisSlack = false;
+                                thisSlack = false;
                             }
                             if (instance.designSpace == designSpace) {
                                 for (var k = 0, l = instance.axes.length; k < l; k++) {

--- a/app/lib/ui/metapolator/glyph/glyph-directive.js
+++ b/app/lib/ui/metapolator/glyph/glyph-directive.js
@@ -1,6 +1,6 @@
 define([
 ], function() {
-    "use strict";
+    'use strict';
     function glyphDirective() {
         return {
             restrict: 'E'
@@ -33,12 +33,14 @@ define([
                 // doesn't have a level (only a name)
                 if (scope.model.level) {
                     // measure the glyph upon first rendering
-                    if (scope.model.type === "master") {
-                        if (!scope.model.measured) {
-                            scope.model.measureGlyph();
+                    if (scope.model.type === 'master') {
+                        scope.model.checkIfIsDisplayed();
+                    } else if (scope.model.type === 'instance') {
+                        // for instances we have to check its master(s) and check the corresponding glyph(s)
+                        var masterGlyphs = scope.model.getMasterGlyphs(scope.model.name);
+                        for (var i = masterGlyphs.length - 1; i >= 0; i--) {
+                            masterGlyphs[i].checkIfIsDisplayed();
                         }
-                    } else if (scope.model.type === "instance") {
-                        scope.checkBaseMasters(scope.model);
                     }
 
                     masterName = scope.model.getMasterName();

--- a/app/lib/ui/metapolator/glyph/glyph-directive.js
+++ b/app/lib/ui/metapolator/glyph/glyph-directive.js
@@ -15,18 +15,18 @@ define([
                 // add css classes for breaks and spaces
                   , parentElement = element.parent()
                   , svg;
-                if (glyphName === "space") {
-                    parentElement.addClass("space-character");
-                } else if (glyphName === "*n") {
+                if (glyphName === 'space') {
+                    parentElement.addClass('space-character');
+                } else if (glyphName === '*n') {
                     // no-glyph is used by the specimenRubberband, to ignore these when making a selection
-                    element.addClass("no-glyph");
-                    parentElement.addClass("line-break");
-                } else if (glyphName === "*p") {
-                    element.addClass("no-glyph");
-                    parentElement.addClass("paragraph-break");
-                } else if (glyphName === "*specimenbreak") {
-                    element.addClass("no-glyph");
-                    parentElement.addClass("specimen-break");
+                    element.addClass('no-glyph');
+                    parentElement.addClass('line-break');
+                } else if (glyphName === '*p') {
+                    element.addClass('no-glyph');
+                    parentElement.addClass('paragraph-break');
+                } else if (glyphName === '*specimenbreak') {
+                    element.addClass('no-glyph');
+                    parentElement.addClass('specimen-break');
                 } 
                 
                 // this is to ignore the fake glyphs, like specimenbreak etc. Their object

--- a/app/lib/ui/metapolator/specimen-panel/specimen-tools/specimen-samples/specimen-samples-controller.js
+++ b/app/lib/ui/metapolator/specimen-panel/specimen-tools/specimen-samples/specimen-samples-controller.js
@@ -5,7 +5,7 @@ define([], function() {
 
         $scope.samples = [[{
             name : "[Enter your own text]",
-            text : "Metapolator"
+            text : "Met"
         }], [{
             name : "3 Pangrams",
             text : "Quick wafting zephyrs vex bold Jim. The quick brown fox jumps over the lazy dog. Bright vixens jump dozy fowl quack."


### PR DESCRIPTION
This fixes #633 (except one piece of work that needs to wait on the export function provided by @felipesanches 

Background:
CPS only works with a `factor` (multiply).
To make operators like `+`, `-`, `=`, etc work, we need to know the 'initial' value of a property. Eg. what is the `width` of a specific `glyph` (without any cps)? If we know the initial value, we can compute the `factor` to provide the desired operation (suppose glyph `A` has a width of 600 and the desired operation is `+60`, the factor becomes 1.1).
To prevent computing time, that is never used, only glyhps that are displayed will be measured and this information is shared among cloned masters (which share the same initial values). Besides being displayed, the measuring also has to be done, when an (ui)instance of that masters has this glyph displayed. And the third case where measuring takes place, is when a font is exported, all glyphs that were never displayed at that time will be measured.
Finally, upon measuring, there is a check if the glyph needs to catch up on cps. Suppose the user  has a `width +100` on master level and has the `A` and `g` displayed. Then he wants the `t` displayed, the `t` will be measured and there needs to be a cps rule for `glyph#t`, with the corresponding factor. The catching up, obviously only needs to happen when there is/are `non-local operators` (like `+`, `-`, `=`, etc) (local or non-local says whether the operator is effective (concerning cps) on the level where it is applied, or at a deeper level (the `effectiveLevel` (eg. the `effectiveLevel` for `weight` is `point` level);  the only 2 `local operators` are `multiply` and `divide`) on a level above the glyph (this level can only be `master` level in the current ui setup).
