### PR TITLE
This fixes #394 and #395

### DIFF
--- a/app/lib/models/metapolator/masters/MasterModel.js
+++ b/app/lib/models/metapolator/masters/MasterModel.js
@@ -70,6 +70,26 @@ define([
             }
         }
     };
-    
+
+    _p.getAllOffspringElements = function() {
+        var elements = []
+          , levelElements = [this]
+          , tempElements = [];
+        while (levelElements.length > 0) {
+            for (var i = 0, l = levelElements.length; i < l; i++) {
+                if (levelElements[i].children) {
+                    for (var j = 0, jl = levelElements[i].children.length; j < jl; j++) {
+                        var child = levelElements[i].children[j];
+                        elements.push(child);
+                        tempElements.push(child);
+                    }
+                }
+            }
+            levelElements = tempElements;
+            tempElements = [];
+        }
+        return elements;
+    };
+
     return MasterModel;
 });

--- a/app/lib/models/metapolator/masters/ParameterModel.js
+++ b/app/lib/models/metapolator/masters/ParameterModel.js
@@ -304,9 +304,6 @@ define([
         var correctionValue
           , parentsFactor;
         parentsFactor = this.element.findParentsFactor(this.base);
-        console.log(this.effectiveValue);
-        console.log(parentsFactor);
-        console.log(this.initial);
         correctionValue = this.effectiveValue / parentsFactor / this.initial;
         this.element.writeValueInCPSfile(correctionValue, this);
     };

--- a/app/lib/models/metapolator/masters/_ElementModel.js
+++ b/app/lib/models/metapolator/masters/_ElementModel.js
@@ -27,12 +27,12 @@ function(
     };
 
     _p.writeValueInCPSfile = function(factor, parameter) {
-    this._updateRuleIndexes(10);
         var parameterCollection
           , cpsRule;
-        if (factor === 1) {
-            this._removeParameter(parameter);
-        } else {
+        // this is commented out, see https://github.com/metapolator/metapolator/issues/394#issuecomment-137112014
+        //if (factor === 1) {
+        //    this._removeParameter(parameter);
+        //} else {
             if (!this.ruleIndex) {
                 this._addRule();
             }
@@ -41,8 +41,8 @@ function(
             var parameterDict = cpsRule.parameters
               , setParameter = cpsAPITools.setParameter;
             setParameter(parameterDict, parameter.base.cpsKey, factor);
-        }
-        //console.log(cpsRule.toString());
+        //}
+        console.log(cpsRule.toString());
     };
 
     _p._removeParameter = function(parameter) {

--- a/app/lib/models/metapolator/masters/_ElementModel.js
+++ b/app/lib/models/metapolator/masters/_ElementModel.js
@@ -29,10 +29,9 @@ function(
     _p.writeValueInCPSfile = function(factor, parameter) {
         var parameterCollection
           , cpsRule;
-        // this is commented out, see https://github.com/metapolator/metapolator/issues/394#issuecomment-137112014
-        //if (factor === 1) {
-        //    this._removeParameter(parameter);
-        //} else {
+        if (factor === 1) {
+            this._removeParameter(parameter);
+        } else {
             if (!this.ruleIndex) {
                 this._addRule();
             }
@@ -41,8 +40,8 @@ function(
             var parameterDict = cpsRule.parameters
               , setParameter = cpsAPITools.setParameter;
             setParameter(parameterDict, parameter.base.cpsKey, factor);
-        //}
-        console.log(cpsRule.toString());
+            //console.log(cpsRule.toString());
+        }
     };
 
     _p._removeParameter = function(parameter) {
@@ -52,25 +51,28 @@ function(
             // if the factor equals 1 and the element already has an index, that means the cps rule is unnecessary
             // so we remove the property in the rule
             var parameterCollection = this.master._project.ruleController.getRule(false, this.master.cpsFile)
-                , ruleIndex = this.ruleIndex
-                , cpsRule = parameterCollection.getItem(ruleIndex);
+              , ruleIndex = this.ruleIndex
+              , cpsRule = parameterCollection.getItem(ruleIndex);
             cpsRule.parameters.erase(parameter.base.cpsKey);
             // if this is the last property in the rule, we remove the rule itself
             // therefor we have to rewrite all the rule indexes of this master
-            // this._removeRule(parameterCollection, ruleIndex);
+            if (cpsRule.parameters.keys().length === 0) {
+                this._removeRule(parameterCollection, ruleIndex);
+            }
         }
     };
 
     _p._addRule = function() {
         if (!this.ruleIndex) {
             var parameterCollection = this.master._project.ruleController.getRule(false, this.master.cpsFile)
-                , l = parameterCollection.length;
+              , l = parameterCollection.length;
             this.ruleIndex = cpsAPITools.addNewRule(parameterCollection, l, this.getSelector());
         }
     };
 
     _p._removeRule = function(parameterCollection, currentRuleIndex) {
         parameterCollection.splice(currentRuleIndex, 1);
+        this.ruleIndex = null;
         this._updateRuleIndexes(currentRuleIndex);
     };
 


### PR DESCRIPTION
When an operator is deleted in the UI, this can have the effect that the corresponding parameter has no operators anymore or that the cps effect for certain elements has to be removed. 
When this happens we erase the parameter (394). If this is the last parameter of the rule, we erase the rule (395) (and update the administration of the rules with a higher index then the just deleted one).