### PR TITLE
Simple math parser

### DIFF
--- a/app/lib/math/simpleMathEngine.js
+++ b/app/lib/math/simpleMathEngine.js
@@ -1,0 +1,123 @@
+define([
+    'metapolator/errors'
+  , 'metapolator/models/CPS/dataTypes/formulae/parsing/Parser'
+  , 'metapolator/models/CPS/dataTypes/formulae/parsing/OperatorToken'
+  , 'metapolator/models/CPS/dataTypes/formulae/parsing/Stack'
+  , 'metapolator/models/CPS/dataTypes/formulae/parsing/NumberToken'
+], function(
+    errors
+  , Parser
+  , Operator
+  , Stack
+  , NumberToken
+) {
+    "use strict";
+
+    var ValueError = errors.Value
+      , CPSFormulaError = errors.CPSFormula
+      , engine
+      ;
+
+    /**
+     * This defines the operators that are usable in simplae math expressions
+     *
+     * see the reference of new Operator for a description of its arguments.
+     *
+     * usage: engine.parse(CPSParameterValueString) returns a Stack
+     */
+    engine = new Parser(
+        /**
+         * When a value is negated using the minus sign, this operator is
+         * inserted instead of the minus sign. It can also be used directly.
+         *
+         * The parser should detect cases where the minus sign is not a
+         * subtraction, but a negation:
+         *
+         * -5 => negate 5
+         * -(5 + name) => negate (5 + name)
+         * 5 + -name => 5 + negate name
+         * 5 + - name => 5 + negate name
+         * name * - 5 => name * negate name
+         *
+         */
+        new Operator('negate', false, 60, 0, 1, [
+            // 'number' as an argument is not needed nor happening
+            // because something like -123 will be parsed as a negative
+            // number directly. This is because "Vector 12 -8" would
+            // otherwise be tokenized as "Vector 12 subtract 8", because
+            // we have no other indication of splitting.
+            // the operator is left in place, so this: --123 could be done
+            // and would result in `negate -123`
+            ['number', function(a){ return -a; }]
+        ])
+          /**
+           * add
+           */
+      , new Operator('+', true, 10, 1, 1, [
+            ['number' , 'number', function(a, b){ return a + b; }]
+        ])
+        /**
+         * subtract
+         */
+      , new Operator('-', true, 10, 1, 1, [
+            ['number' , 'number', function(a, b){ return a - b; }]
+        ])
+        /**
+         * multiply
+         */
+      , new Operator('*', true, 20, 1, 1, [
+           ['number' , 'number', function(a, b){ return a * b; }]
+        ])
+        /**
+         * divide
+         */
+      , new Operator('/', true, 20, 1, 1, [
+            ['number' , 'number', function(a, b){ return a / b; }]
+        ])
+        /**
+         * pow
+         */
+      , new Operator('^', true, 30, 1, 1, [
+            ['number' , 'number', function(a, b){ return Math.pow(a, b); }]
+        ])
+      , new Operator('min', true, 40, 0, 2, [
+            ['number' , 'number', function(a, b){ return Math.min(a, b); }]
+        ])
+      , new Operator('max', true, 40, 0, 2, [
+            ['number' , 'number', function(a, b){ return Math.max(a, b); }]
+      ])
+    );
+
+    function SimpleMathStack(postfixStack) {
+        Stack.call(this, postfixStack);
+    }
+    var _p = SimpleMathStack.prototype = Object.create(Stack.prototype);
+    _p.constructor = SimpleMathStack;
+
+    _p._check = function(stack) {
+        var i, l, invalid=[];
+        for(i=0,l=stack.length;i<l;i++) {
+            // whitelisting allowed tokens
+            if(!(stack[i] instanceof NumberToken || stack[i] instanceof Operator))
+                invalid.push(stack[i]);
+        }
+        if(invalid.length)
+            throw new CPSFormulaError('The math expression contains invalid tokens: ' + invalid.join(', '));
+        return Stack.prototype._check.call(this, stack);
+    }
+
+    /**
+     * This method is applied in Stack.execute, with the result of the stack execution.
+     *
+     * OperatorToken._convertTokenToValue does something similar.
+     */
+    _p._finalizeMethod = function(result, getAPI) {
+        if(typeof result != 'number')
+            throw new CPSFormulaError('The math expression did not yield in a number. Got instead: ' + result);
+        return result;
+    };
+
+    engine.setNegateOperator('-', 'negate');
+    engine.setStackConstructor(SimpleMathStack);
+    return engine;
+});

--- a/app/lib/models/CPS/dataTypes/formulae/formulaEngine.js
+++ b/app/lib/models/CPS/dataTypes/formulae/formulaEngine.js
@@ -1,11 +1,9 @@
 define([
     'metapolator/errors'
   , './parsing/Parser'
+  , './parsing/Stack'
   , './parsing/OperatorToken'
   , './parsing/NameToken'
-  , './parsing/SelectorToken'
-  , './parsing/StringToken'
-  , './parsing/NumberToken'
   , './parsing/_Token'
   , 'metapolator/models/CPS/elements/SelectorList'
   , 'metapolator/models/MOM/_Node'
@@ -16,11 +14,9 @@ define([
 ], function(
     errors
   , Parser
+  , Stack
   , Operator
   , NameToken
-  , SelectorToken
-  , StringToken
-  , NumberToken
   , _Token
   , SelectorList
   , _MOMNode
@@ -362,14 +358,19 @@ define([
                                             return transform.Identity;})
     );
 
+
+    function CPSStack(postfixStack) {
+        Stack.call(this, postfixStack);
+    }
+    var _p = CPSStack.prototype = Object.create(Stack.prototype);
+    _p.constructor = CPSStack;
+
     /**
-     * FIXME: I'm not sure where to put this functionality. Also, note
-     * that OperatorToken._convertTokenToValue does something similar.
+     * This method is applied in Stack.execute, with the result of the stack execution.
      *
-     * This method is passed from Parser to new Stack and then run in
-     * Stack.execute, with the result of the stack execution.
+     * OperatorToken._convertTokenToValue does something similar.
      */
-    engine.setFinalizeMethod(function(result, getAPI) {
+    _p._finalizeMethod = function(result, getAPI) {
         if(result instanceof NameToken)
             return getAPI.get(result.getValue());
         else if(result instanceof SelectorList) {
@@ -386,8 +387,10 @@ define([
             throw new CPSFormulaError('It is not allowed for a stack to '
                 + 'resolve into a _Token, but this Stack did: ' + result);
         return result;
-    });
+    };
+
     engine.setBracketOperator('[', '__get__');
     engine.setNegateOperator('-', 'negate');
+    engine.setStackConstructor(CPSStack);
     return engine;
 });

--- a/app/lib/models/CPS/dataTypes/formulae/parsing/Parser.js
+++ b/app/lib/models/CPS/dataTypes/formulae/parsing/Parser.js
@@ -2,7 +2,6 @@ define([
     'metapolator/errors'
   , './_ValueToken'
   , './OperatorToken'
-  , './Stack'
   , './BracketToken'
   , './StringToken'
   , './SelectorToken'
@@ -12,7 +11,6 @@ define([
     errors
   , _ValueToken
   , OperatorToken
-  , Stack
   , BracketToken
   , StringToken
   , SelectorToken
@@ -40,7 +38,7 @@ define([
 
         this._bracketOperators = {};
         this._negateOperator = undefined;
-        this._finalizeMethod = undefined;
+        this._StackConstructor = undefined;
     }
 
     var _p = Parser.prototype
@@ -158,13 +156,8 @@ define([
         return result;
     };
 
-    /**
-     * The method is passed from Parser.parse to new Stack and then run in
-     * Stack.execute, with the result of the stack execution and getAPI as
-     * arguments.
-     */
-    _p.setFinalizeMethod = function(method) {
-        this._finalizeMethod = method;
+    _p.setStackConstructor = function(ctor){
+        this._StackConstructor = ctor;
     };
 
     _p.setBracketOperator = function(bracketLiteral, operatorLiteral) {
@@ -644,11 +637,13 @@ define([
      * immediately, contrary to beeing compiled when first used.
      */
     _p.parse = function(string, selectorEngine) {
+        if(!this._StackConstructor)
+            throw new CPSFormulaError('StackConstructor is missing. Run engine.setStackConstructor before running engine.parse.');
         var tokens = this.tokenize(string, selectorEngine);
         tokens = this.infixToPostfix(tokens);
         if(!tokens.length)
             throw new CPSFormulaError('The input string did not produce any instructions.');
-        return new Stack(tokens, this._finalizeMethod);
+        return new this._StackConstructor(tokens);
     };
 
     return Parser;

--- a/app/lib/models/CPS/dataTypes/formulae/parsing/Stack.js
+++ b/app/lib/models/CPS/dataTypes/formulae/parsing/Stack.js
@@ -18,10 +18,9 @@ define([
       ;
 
 
-    function Stack(postfixStack, finalizeMethod) {
+    function Stack(postfixStack) {
         // raises CPSFormulaError
         this._check(postfixStack);
-        this._finalizeMethod = finalizeMethod;
         var sig;
         this._signature = sig = this._makeSignature(postfixStack);
         this._stack = this._unwrap(postfixStack);
@@ -34,6 +33,9 @@ define([
     _p.toString = function() {
         return this._stack.join('|');
     };
+
+    // define via inheritance
+    _p._finalizeMethod = null;
 
     Object.defineProperty(_p, 'items', {
         get: function(){ return this._stack.slice(); }


### PR DESCRIPTION
#653
@allcaps 

Here is a small session in `metapolator dev-js-shell` to show you how to use this:

```
$ metapolator dev-js-shell
metapolator> me = require('metapolator/math/simpleMathEngine');
# prints the `me` object
metapolator> me.parse('1+2*3').execute()
7
metapolator> me.parse('(1+2)*3').execute()
9
metapolator> me.parse('(1,3+2,2)*3'.replace(/,/g, '.')).execute()
10.5

# note, This throws some sorts of CPS errors, like here:
metapolator> me.parse('hello').execute()
CPSFormulaError: The math expression contains invalid tokens: <NameToken: hello>
    at SimpleMathStack._p._check (/home/commander/Projekte/metapolator/master/app/lib/math/simpleMathEngine.js:105:19)
    at SimpleMathStack.Stack (/home/commander/Projekte/metapolator/master/app/lib/models/CPS/dataTypes/formulae/parsing/Stack.js:23:14)
    at new SimpleMathStack (/home/commander/Projekte/metapolator/master/app/lib/math/simpleMathEngine.js:92:15)
    at Parser._p.parse (/home/commander/Projekte/metapolator/master/app/lib/models/CPS/dataTypes/formulae/parsing/Parser.js:646:16)
    at repl:1:5
    at REPLServer.self.eval (repl.js:112:21)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.emit (events.js:95:17)
    at Interface._onLine (readline.js:203:10)
    at Interface._line (readline.js:532:8)

# or here:
metapolator> me.parse('1++2').execute()
CPSFormulaError: Malformed stack at a "+" operator, which consumes another operator: "+"
    at Parser.infixToPostfix (/home/commander/Projekte/metapolator/master/app/lib/models/CPS/dataTypes/formulae/parsing/Parser.js:608:31)
    at Parser._p.parse (/home/commander/Projekte/metapolator/master/app/lib/models/CPS/dataTypes/formulae/parsing/Parser.js:643:23)
    at repl:1:5
    at REPLServer.self.eval (repl.js:112:21)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.emit (events.js:95:17)
    at Interface._onLine (readline.js:203:10)
    at Interface._line (readline.js:532:8)
    at Interface._ttyWrite (readline.js:761:14)
    at ReadStream.onkeypress (readline.js:100:10)
```

To catch all of these errors, but to not silence too many; I recommend this code layout:

```js
define([
    'metapolator/errors'
  , 'metapolator/math/simpleMathEngine'
], function(
    errors
  , mathEngine
) {
    var CPSError = errors.CPS
    // in the code then:
    var result, message;
    try {
        result = mathEngine.parse(input.replace(/,/g,'.')).execute()
    } catch (e) {
        if(!(e instanceof CPSError))
            throw e; // re-raise, so that we can fix it

        // inform the user if this is possible via the ui
        // or do whatever you do when the input was bad
        message = e.message;
    }
    // NOTE: result can still be: `Infinity`, `-Infinity`, `NaN`  because that's reasonable for math
    // check with:
    isFinite(result)
    // and of course `undefined`  if there was an error, but: isFinite(undefined) === false

    // go on here
});


```


