### PR TITLE
Set glyph view box min width to 0.

### DIFF
--- a/app/lib/ui/services/GlyphRendererAPI.js
+++ b/app/lib/ui/services/GlyphRendererAPI.js
@@ -234,6 +234,8 @@ define([
     };
 
     _p._applySVGViewBox = function(svg, viewBox) {
+        // Viewbox min width can't be less than 0.
+        viewBox[2] = Math.max(0, viewBox[2]);
         svg.setAttribute('viewBox', viewBox.join(' '));
         if(!svg.parentElement || this._options.noParentSizing)
             return;


### PR DESCRIPTION
Negative width gives these error(s).
> GlyphRendererAPI.js:239 Error: Invalid negative value for <svg> attribute viewBox="0 0 -2.025000000000131 1200"_p._applySVGViewBox

When width is set to a negative value the SVGViewBox should have a width of 0. 