### PR TITLE
Element styles

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,7 @@
 {
+    "undef": true,
+    // is useful but not as a default "unused": true,
+    "globals": {"define": false, "require": false},
     "laxcomma": true,
     "laxbreak": true
 }

--- a/app/lib/models/CPS/SelectorEngine.js
+++ b/app/lib/models/CPS/SelectorEngine.js
@@ -244,7 +244,7 @@ define([
                     // anyways
                     specificity = complexSelectors[j].specificity.slice();
                     specificity.push(i);
-                    matchingRules.push([specificity, namespacedRule[1]]);
+                    matchingRules.push([specificity, namespacedRule]);
                     break;
                 }
             }

--- a/app/lib/models/CPS/StyleDict.js
+++ b/app/lib/models/CPS/StyleDict.js
@@ -416,12 +416,12 @@ define([
      * Subscribes to propertyDict and property changes and updates
      */
     _p._buildIndex = function() {
-        assert(this._dict === null, 'Index alreay initializes, run invalidateRules to purge it.');
+        assert(this._dict === null, 'Index already initialized, run invalidateRules to purge it.');
         var i, l, j, ll, keys, key, parameters, subscriberID;
         this._loadRules();
         this._dict = Object.create(null);
         for(i=0,l=this._rules.length;i<l;i++) {
-            parameters = this._rules[i].parameters;
+            parameters = this._rules[i][1].parameters;
 
             subscriberID = parameters.on('add', [this, '_parameterAddHandler'], i);
             this._dictSubscriptions.push([parameters, subscriberID]);
@@ -552,7 +552,7 @@ define([
                         + 'to the new one, but it is.\n index: ' + newRuleIndex
                         + ' key: ' + key
                         + ' channel: ' + channelKey);
-        this._setDictValue(this._rules[newRuleIndex].parameters, key, newRuleIndex);
+        this._setDictValue(this._rules[newRuleIndex][1].parameters, key, newRuleIndex);
     };
 
     _p._setDictValue = function(parameters, key, parametersIndex) {
@@ -578,7 +578,7 @@ define([
         var i, l, parameters;
         this._unsetDictValue(key);
         for(i=0,l=this._rules.length;i<l;i++) {
-            parameters = this._rules[i].parameters;
+            parameters = this._rules[i][1].parameters;
             if(!parameters.has(key))
                 continue;
             this._setDictValue(parameters, key, i);

--- a/app/lib/models/CPS/StyleDict.js
+++ b/app/lib/models/CPS/StyleDict.js
@@ -400,14 +400,23 @@ define([
     };
 
     _p._loadRules = function(force) {
-        if(this._rules === null || force)
-            //this call is most expensive
-            this._rules = this._controller.getRulesForElement(this.element);
+        var rules;
+        if(this._rules === null || force) {
+            //FIXME: duck typing, in the future the naming will all be
+            // properties instead of parameters. Then a rule and the element
+            // will both provide the `properties` interface.
+            // also, "rules" is not exactly right here, when we also have the
+            // element.properties in here.
+            this._rules = rules = [[null, {parameters: this.element.properties}, null]];
+            Array.prototype.push.apply(rules,
+                        //this call is most expensive
+                        this._controller.getRulesForElement(this.element));
+        }
     };
 
-    _p.getRules = function(rules) {
+    _p.getRules = function(includeElementProperties) {
         if(!this._dict) this._buildIndex();
-        return this._rules.slice();
+        return this._rules.slice(includeElementProperties ? 0 : 1);
     };
 
     /**

--- a/app/lib/models/CPS/elements/AtNamespaceCollection.js
+++ b/app/lib/models/CPS/elements/AtNamespaceCollection.js
@@ -104,7 +104,10 @@ define([
             // e.g. via _structuralChangeHandler. So, the second call to
             // a not cleared child collection performs namespace.multiply
             // a second time on the same rules item.
-            rules[i] = [namespace.multiply(rules[i][0]), rules[i][1]];
+            //rules[i] = [namespace.multiply(rules[i][0]), rules[i][1], rules[i][2]];
+
+            // The copy is not needed at the moment because now ParameterCollection._getRules
+            rules[i][0] = namespace.multiply(rules[i][0])
         }
         return rules;
     };

--- a/app/lib/models/MOM/_Node.js
+++ b/app/lib/models/MOM/_Node.js
@@ -97,6 +97,13 @@ define([
             clone.setClass(k);
     };
 
+    _p.walkTreeDepthFirst = function(callback) {
+        var i,l;
+        callback(this);
+        for(i=0,l=this.children.length;i<l;i++)
+            this.children[i].walkTreeDepthFirst(callback);
+    }
+
     emitterMixin(_p, emitterMixinSetup);
 
     Object.defineProperty(_p, 'MOMType', {

--- a/app/lib/models/MOM/_Node.js
+++ b/app/lib/models/MOM/_Node.js
@@ -3,11 +3,13 @@ define([
   , '../_BaseModel'
   , 'metapolator/models/CPS/whitelistProxies'
   , 'metapolator/models/emitterMixin'
+  , 'metapolator/models/CPS/elements/ParameterDict'
 ], function(
     errors
   , Parent
   , whitelistProxies
   , emitterMixin
+  , ParameterDict
 ) {
     "use strict";
 
@@ -48,6 +50,16 @@ define([
         this._id = null;
         this._classes = Object.create(null);
         this.cps_proxy = whitelistProxies.generic(this, this._cps_whitelist);
+
+        // this has higher precedence than any rule loaded by CPS
+        // and it is unique to this _Node.
+        // DOM Elements have element.style, this is analogous
+        Object.defineProperty(this, 'properties', {
+            value: new ParameterDict([], '*element properties*')
+          , enumerable: true
+        });
+
+
         this._changeSubscriptions = null;
         emitterMixin.init(this, emitterMixinSetup);
 

--- a/app/lib/project/MetapolatorProject.js
+++ b/app/lib/project/MetapolatorProject.js
@@ -523,11 +523,30 @@ define([
         return this._cache.masters[masterName];
     };
 
+    _p._loadElementProperties = function(propertiesFile, momMaster) {
+        // get the rules ...
+        var parameterCollection = this.ruleController.getRule(false, propertiesFile)
+          , allRules = parameterCollection.rules
+          , newProperties
+          , rules
+          ;
+
+        function setProperties(element) {
+            /*jshint validthis: true*/
+            rules = this._controller._selectorEngine.getMatchingRules(allRules, element);
+            if(!rules[0]) return;
+            newProperties = rules[0][1].parameters.items;
+            element.properties.splice(0, element.properties.length, newProperties);
+        }
+        momMaster.walkTreeDepthFirst(setProperties.bind(this));
+    };
+
     _p.open = function(masterName) {
         if(!this._controller.hasMaster(masterName)) {
             // this._log.warning('open', masterName)
             var master = this.getMaster(masterName)
             , skeleton = this._data.masters[masterName].skeleton
+            , propertiesFile = this._data.masters[masterName].propertiesFile
             , sourceMOM
             , momMaster
             ;
@@ -541,6 +560,9 @@ define([
             momMaster = sourceMOM.clone();
 
             momMaster.id = masterName;
+
+            if(propertiesFile)
+                this._loadElementProperties(propertiesFile, momMaster);
             this._controller.addMaster(momMaster, master._cpsFile);
         }
         return this._controller;

--- a/app/lib/ui/redPill/app.less
+++ b/app/lib/ui/redPill/app.less
@@ -203,7 +203,9 @@ mtk-cps-panel {
 
 
     mtk-cps-property-dict::before {
-        content: '{'
+        content: '{';
+        vertical-align: bottom;
+
     }
     mtk-cps-property-dict::after {
         content: '}';

--- a/app/lib/ui/redPill/cpsPanel/cpsPanel-directive.js
+++ b/app/lib/ui/redPill/cpsPanel/cpsPanel-directive.js
@@ -11,13 +11,14 @@ define([
                 /*jshint validthis: true*/
                 this.setter = null;
                 if(this.newHeight === null) return;
-                this.element.style.height = this.newHeight + 'px';
+                this.element.style.height = this.newHeight + '%';
                 this.newHeight = null;
             }
 
             function changeHeight(event) {
                 /*jshint validthis: true*/
-                this.newHeight = this.startY - event.screenY + this.startHeight;
+                var height = this.startY - event.screenY + this.startHeight;
+                this.newHeight = height/document.documentElement.clientHeight * 100;
                 if(!this.setter)
                     this.setter = document.defaultView.requestAnimationFrame(setHeight.bind(this));
             }

--- a/app/lib/ui/redPill/cpsPanel/elements/propertyDict/propertyDict-directive.js
+++ b/app/lib/ui/redPill/cpsPanel/elements/propertyDict/propertyDict-directive.js
@@ -154,8 +154,24 @@ define([
             element[0].addEventListener('dragover', dropHelper.dragoverHandler);
             element[0].addEventListener('drop', dropHelper.dropHandler);
 
+            // new property:
+            function initNewProperty() {
+                // open a new-property interface
+                scope.newProperty = true;
+            }
+            function cancelNewProperty() {
+                // if a new-property is open: close it
+                scope.newProperty = false;
+            }
+            var finalizeNewProperty = cancelNewProperty;
+
+            scope.newProperty = false;
+            scope.$on('finalizeNewProperty', finalizeNewProperty);
+            scope.$on('newPropertyRequest', helpers.handlerDecorator(scope,
+                                    initNewProperty, true, true));
             angular.element(container).on('dblclick', helpers.handlerDecorator(scope,
                             scope.$emit.bind(scope, 'newPropertyRequest'), true, false));
+
         }
 
         return {

--- a/app/lib/ui/redPill/cpsPanel/elements/propertyDict/propertyDict.tpl
+++ b/app/lib/ui/redPill/cpsPanel/elements/propertyDict/propertyDict.tpl
@@ -37,7 +37,7 @@
 
             ></mtk-cps-generic>
     </li>
-    <li ng-if="$parent.newProperty" >
+    <li ng-if="newProperty" >
         new <mtk-cps-new-property
             cps-property-dict="controller.cpsPropertyDict"
         ></mtk-cps-new-property>

--- a/app/lib/ui/redPill/cpsPanel/elements/rule/rule-controller.js
+++ b/app/lib/ui/redPill/cpsPanel/elements/rule/rule-controller.js
@@ -9,30 +9,11 @@ define([
     function RuleController($scope) {
         this.$scope = $scope;
         $scope.index = this.index;
-        this.initNewPropertyHandler = this.initNewProperty.bind(this);
-        this.cancelNewPropertyHandler = this.cancelNewProperty.bind(this);
-        $scope.newProperty = false;
-        $scope.$on('finalizeNewProperty', this.finalizeNewProperty.bind(this));
         this.toolClickHandler = clickHandler.bind(this, 'command');
     }
 
     RuleController.$inject = ['$scope'];
     var _p = RuleController.prototype;
-
-    _p.cancelNewProperty = function() {
-        // if a new-property is open: close it
-        this.$scope.newProperty = false;
-    };
-
-    // this is currently an alias of cancelNewProperty
-    // because the new-property controller will add the new property
-    // itself to the model
-    _p.finalizeNewProperty = _p.cancelNewProperty;
-
-    _p.initNewProperty = function() {
-        // open a new-property interface
-        this.$scope.newProperty = true;
-    };
 
     return RuleController;
 });

--- a/app/lib/ui/redPill/cpsPanel/elements/rule/rule-directive.js
+++ b/app/lib/ui/redPill/cpsPanel/elements/rule/rule-directive.js
@@ -11,12 +11,6 @@ define([
 
     function RuleDirective() {
         function link(scope, element, attrs, controller) {
-            element.bind('click', helpers.handlerDecorator(scope,
-                            controller.cancelNewPropertyHandler, true, true));
-
-            scope.$on('newPropertyRequest', helpers.handlerDecorator(scope,
-                            controller.initNewPropertyHandler, true, true));
-
             scope.updateUsedNames = function(usedNamesSet) {
                 var i,l,children = element[0].children, child, scope;
                 for(i=0,l=children.length;i<l;i++) {

--- a/app/lib/ui/redPill/cpsPanel/elements/selectorList/selectorList-controller.js
+++ b/app/lib/ui/redPill/cpsPanel/elements/selectorList/selectorList-controller.js
@@ -115,7 +115,7 @@ define([
             // valid: *:a(0) as: *:a
             // an unkown pseudo-class should create a message not be silently
             // discarded!
-            console.log('valid:', this.$scope.selectorList, 'as: '+ selectorList);
+            console.warn('valid:', this.$scope.selectorList, 'as: '+ selectorList);
             // update ...
             this._updateSelectorList(selectorList);
         }

--- a/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict-controller.js
+++ b/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict-controller.js
@@ -31,7 +31,7 @@ define([
     var _p = StyleDictController.prototype;
 
     _p._resetItems = function(){
-        this.items = this._styleDict.getRules();
+        this.items = this._styleDict.getRules(false);
     };
 
     _p.__updateNames = function() {

--- a/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict-directive.js
+++ b/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict-directive.js
@@ -9,16 +9,54 @@ define([
 
     function styleDictDirective() {
         function link(scope, element, attrs, controller) {
+            scope.formatTrace = function(trace) {
+                var i, item, result = [], depth = '';
+                for(i=trace.length-1;i>=0;i--) {
+                    item = trace[i];
+                    switch(item.constructor.name) {
+                        case 'ParameterCollection':
+                            // NOTE: the first of these probably did not get @imported
+                            // the others most probably got.
+                            // We should however rather add the @import items to the trace
+                            // as it is easier to extend if other sources for
+                            // ParameterCollections come into being, like @generate
+                            // ParameterCollection could be ignored.
+                            // The first parameter collection, however helps
+                            // to identify the "master cps file" that is useful
+                            // information! (and not @imported ...)
+                            result.push(depth + '@import "'+item.source.name+'";');
+                            break;
+                        case 'AtNamespaceCollection':
+                            result.push(depth + '@namespace('+ item.selectorList + ')');
+                            break;
+                        default:
+                        result.push(depth + item.constructor.name);
+                    }
+                    depth = depth + '  ';
+                }
+                return result.join('\n');
+            };
+
             scope.updateNames = function(usedNamesSet) {
-                var i,l,children = element[0].children, child;
-                for(i=0,l=children.length;i<l;i++) {
-                    child = children[i];
-                    if(child.tagName.toLowerCase() !== 'mtk-cps-rule')
-                        continue;
-                    angular.element(child)
+                var i,l,j
+                    , containers = element[0].getElementsByClassName('container')[0].children
+                    , container, child
+                    ;
+                for(i=0,l=containers.length;i<l;i++) {
+                    container = containers[i];
+                    // assume that child is rather at the end of the container
+                    // element. At the moment of writing this reflects the
+                    // DOM layout
+                    for(j=container.children.length-1;j>=0;j--) {
+                        child = container.children[j];
+                        if(child.tagName.toLowerCase() !== 'mtk-cps-rule')
+                            continue;
+                        // there's just one child
+                        angular.element(child)
                            .isolateScope()
                            .updateUsedNames(usedNamesSet);
-
+                        break;
+                    }
                 }
             };
         }

--- a/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict-directive.js
+++ b/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict-directive.js
@@ -41,6 +41,7 @@ define([
                 var i,l,j
                     , containers = element[0].getElementsByClassName('container')[0].children
                     , container, child
+                    , childTags = new Set(['mtk-cps-rule', 'mtk-cps-property-dict'])
                     ;
                 for(i=0,l=containers.length;i<l;i++) {
                     container = containers[i];
@@ -49,12 +50,12 @@ define([
                     // DOM layout
                     for(j=container.children.length-1;j>=0;j--) {
                         child = container.children[j];
-                        if(child.tagName.toLowerCase() !== 'mtk-cps-rule')
+                        if(!childTags.has(child.tagName.toLowerCase()))
                             continue;
-                        // there's just one child
                         angular.element(child)
                            .isolateScope()
                            .updateUsedNames(usedNamesSet);
+                        // there's just one child per container
                         break;
                     }
                 }

--- a/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict.tpl
+++ b/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict.tpl
@@ -1,6 +1,31 @@
 <div>{{ctrl.element.particulars}}</div>
-<mtk-cps-rule
-        ng-repeat="item in ctrl.items track by $index + ':' + item.nodeID"
-        item="item"
+<ol class="container">
+<li ng-repeat="item in ctrl.items track by $index + ':' + item[1].nodeID">
+    <div ng-repeat="traceItem in item[2].slice().reverse()  track by $index"
+        ng-switch="traceItem.constructor.name"
+        style="padding-left: calc({{$index}} * 1em)"
+        ><div
+            ng-switch-when="ParameterCollection"
+            style="font-family: monospace;"
+            ><span ng-if="$index != 0">@import</span>
+             <span ng-if="$index == 0">root file:</span>
+             "{{traceItem.source.name}}";</div><!--
+
+             FIXME:TODO: I think it is bad having these mtk-cps-selector-list
+             elements here to be changed because it's not obvious that the
+             namespaces (usually) contain more rules. It would be better to
+             have links here that load the cps-collection which contains
+             the namespace and scroll there to the definition of that
+             namespace.
+        --><div
+            ng-switch-when="AtNamespaceCollection">@namespace(<mtk-cps-selector-list
+            selector-list-host="traceItem"
+            ></mtk-cps-selector-list>)</div><!--
+    --></div>
+    <mtk-cps-rule
+        style="padding-left: calc({{item[2].length}} * 1em)"
+        item="item[1]"
         index="$index"
     ></mtk-cps-rule>
+</li>
+<ol>

--- a/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict.tpl
+++ b/app/lib/ui/redPill/cpsPanel/elements/styleDict/styleDict.tpl
@@ -1,5 +1,11 @@
 <div>{{ctrl.element.particulars}}</div>
 <ol class="container">
+<li>
+    element properties
+    <mtk-cps-property-dict
+        cps-property-dict="ctrl.element.properties"
+        ></mtk-cps-property-dict>
+</li>
 <li ng-repeat="item in ctrl.items track by $index + ':' + item[1].nodeID">
     <div ng-repeat="traceItem in item[2].slice().reverse()  track by $index"
         ng-switch="traceItem.constructor.name"


### PR DESCRIPTION
As a reaction on https://github.com/metapolator/metapolator/pull/659#issuecomment-143766650 ff.

Add `MOM _Node.properties`, which is a `PropertyDict` (still mostly named as `ParameterDict` in the code), A `PropertyDict` is the same thing that a `Rule` uses to store its CPS Properties.

The `PropertyDict` at `MOMnode.properties` has always highest specificity over all rules defined in the CPS files. It is thus analogous to the `element.style` property of DOM-elements and a neat API for the Metapolator-UI and other coding purposes.

When a CPS file is used at the `propertiesFile` key in a master definition of project.yaml, that file will be used to initiate the all `element.properties` of that master upon initiation.

```yaml
masters:
  base:
    cpsFile: base.cps
    skeleton: skeleton.base
    propertiesFile: elementPropertiesDB/base.cps
```
In this example I changed the original `base.cps` to only include the important `@import` rules and moved the many "data" rules created on import to `/data/com.metapolator/cps/elementPropertiesDB/base.cps`

That means I made 2 files out of one: https://github.com/metapolator/project_zero/blob/master/project_zero.mp/data/com.metapolator/cps/base.cps https://github.com/metapolator/project_zero/blob/master/project_zero.mp/data/com.metapolator/cps/elementPropertiesDB/base.cps

You don't have to do this now, if you don't want to use the base.cps values as `node.properties` it will continue to work as it was.

We don't do that on import yet. (I'll file an issue for me).
We also don't export these `propertiesFile`s when we save the project.

It's important to understand that changes to the `propertiesFile` or its `parameterCollection` object won't affect the elementProperties after they are set. I will make a more rigorous separation between these things.











Also included: small update to the dev tool (show the rules "position" in the CPS)