### PR TITLE
Un hardcoded master cps rule approach

### DIFF
--- a/app/lib/models/metapolator/masters/MasterModel.js
+++ b/app/lib/models/metapolator/masters/MasterModel.js
@@ -25,7 +25,7 @@ define([
         this.master = this;
         this.cpsFile = cpsFile;
         this.MOMelement = MOMelement;
-        this.ruleIndex = 3;
+        this.ruleIndex = null;
 
         this.setInitialParameters();
     }

--- a/app/lib/ui/metapolator/specimen-panel/specimen-tools/specimen-samples/specimen-samples-controller.js
+++ b/app/lib/ui/metapolator/specimen-panel/specimen-tools/specimen-samples/specimen-samples-controller.js
@@ -5,7 +5,7 @@ define([], function() {
 
         $scope.samples = [[{
             name : "[Enter your own text]",
-            text : "Met"
+            text : "Metapolator"
         }], [{
             name : "3 Pangrams",
             text : "Quick wafting zephyrs vex bold Jim. The quick brown fox jumps over the lazy dog. Bright vixens jump dozy fowl quack."


### PR DESCRIPTION
See https://github.com/metapolator/metapolator/pull/659#issuecomment-143876583

This way of overruling the hardcoded master cps rule in parameters.cps, with the same strength of selector (both `master`) but because it has a higher index, it overrules the standard. Plus it has the advantage of being easy to copy.