### PR TITLE
Current/latest nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,22 @@
+sudo: false
+
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+
+# These are workarounds for travis not building libxmljs
+# found here: https://github.com/polotek/libxmljs/issues/339#issuecomment-142504275
+# It is likeley that we wont need this for a long time.
+env:
+    - CXX=g++-4.8
+
+addons:
+    apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-4.8
+

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   "dependencies": {
     "commander": "~2.3.0",
     "express": "~4.7.2",
-    "jsdom": "~0.10.5",
-    "libxmljs": "~0.14.2",
+    "jsdom": "~3",
+    "libxmljs": "~0.15.0",
     "requirejs": "~2.1.14",
     "lie": "~2.7.6",
     "immutable-complex": "~3.0.4",


### PR DESCRIPTION
This is related: #687

With this PR we get passing tests on Travis for node: 0.10{.latest}, 0.12{.latest}, 4{.latest}, 5{.latest}

On my local machine node 5.1.0 works so far.

Probably we can also update /INSTALL.md then.
