### PR TITLE
#710

### DIFF
--- a/app/lib/models/metapolator/AppModel.js
+++ b/app/lib/models/metapolator/AppModel.js
@@ -21,12 +21,9 @@ define([
         this.designSpaces = [];
         this.designSpaceCounter = 0;
         this.currentDesignSpace = null;
-        this.currentDesignSpaceTrigger = 0;
-        this.nrOfAxesTrigger = 0;
         //
         this.instanceSequences = [];
         this.currentInstance = null;
-        this.currentInstanceTrigger = 0;
         //
         this.localMenu = null;
         this.viewState = 0;

--- a/app/lib/models/metapolator/designSpaces/DesignSpaceModel.js
+++ b/app/lib/models/metapolator/designSpaces/DesignSpaceModel.js
@@ -11,7 +11,6 @@ define([
         this.axes = axes;
         this.slack = slack;
         this.lastInstance = null;
-        
         Object.defineProperty(this, 'parent', {
             value: parent,
             enumerable: false,
@@ -45,7 +44,6 @@ define([
 
     _p.setCurrent = function() {
         this.parent.currentDesignSpace = this;
-        this.parent.currentDesignSpaceTrigger++;
     };
 
     _p.isCurrent = function() {

--- a/app/lib/models/metapolator/instances/InstanceModel.js
+++ b/app/lib/models/metapolator/instances/InstanceModel.js
@@ -30,7 +30,6 @@ define([
         this.openTypeFeatures = true;
         this.cpsFile = this.name + '.cps';
         this._project = project;
-
         Object.defineProperty(this, 'parent', {
             value: parent,
             enumerable: false,
@@ -63,11 +62,6 @@ define([
     _p.setCurrent = function() {
         this.parent.parent.currentInstance = this;
         this.designSpace.setLastInstance(this);
-        // todo: get rid of these 2.
-        // the first by refactoring the design space
-        // the second by refactoring the specimen
-        this.parent.parent.currentInstanceTrigger++;
-
     };
 
     _p.isCurrent = function() {
@@ -160,13 +154,9 @@ define([
             // 2 find ratio of others compared to highest
             ratio = 100 / (parseFloat(max) + parseFloat(axes[slack].axisValue));
             for (var j = 0; j < l; j++) {
-                axes[j].axisValue = this._formatAxisValue(ratio * axes[j].axisValue);
+                axes[j].axisValue = (ratio * axes[j].axisValue).toFixed(1);
             }
         }
-    };
-    
-    _p._formatAxisValue = function(x) {
-        return Math.round(x * 10) / 10;
     };
 
     _p._getIndex = function() {

--- a/app/lib/ui/metapolator/design-space-panel/control/control-controller.js
+++ b/app/lib/ui/metapolator/design-space-panel/control/control-controller.js
@@ -24,6 +24,7 @@ define([
                     }
                 }
             }
+            $scope.redraw();
         };
         
         $scope.redrawAxesFromInput = function(inputAxis, keyEvent) {
@@ -61,7 +62,7 @@ define([
                     }
                 }
                 instance.setMetapolationValues();
-                console.log("wants a design space redraw");
+                $scope.redraw();
             }
             
             function format(value) {

--- a/app/lib/ui/metapolator/design-space-panel/control/control-controller.js
+++ b/app/lib/ui/metapolator/design-space-panel/control/control-controller.js
@@ -14,21 +14,16 @@ define([
         };
         
         $scope.changeSlackMaster = function() {
-            var designSpace = $scope.model;
-            var slack = designSpace.slack;
             // swop main master in each instance in the design space
-            for (var i = $scope.model.instances.length - 1; i >= 0; i--) {
-                var sequence = $scope.model.instances.sequences[i];
+            for (var i = $scope.model.parent.instanceSequences.length - 1; i >= 0; i--) {
+                var sequence = $scope.model.parent.instanceSequences[i];
                 for (var j = sequence.children.length - 1; j >= 0; j--) {
                     var instance = sequence.children[j];
-                    if (instance.designSpace == designSpace) {
-                        instance.reDestributeAxes(slack);
+                    if (instance.designSpace === $scope.model) {
+                        instance.reDestributeAxes($scope.model.slack);
                     }
                 }
-                
             }
-            // trigger the designspace to redraw
-            designSpace.parent.currentDesignSpaceTrigger++;
         };
         
         $scope.redrawAxesFromInput = function(inputAxis, keyEvent) {
@@ -37,11 +32,11 @@ define([
                   , slack = designSpace.slack
                   , instance = designSpace.lastInstance
                   , axes = instance.axes
-                  , l = axes.length;
+                  , l = axes.length
+                  , max = 0;
                 axes[inputAxis].value = format(axes[inputAxis].value);
 
                 // find the highest non-slack master
-                var max = 0;
                 for (var i = 0; i < l; i++) {
                     if (parseFloat(axes[i].axisValue) >= max && i != slack) {
                         max = parseFloat(axes[i].axisValue);
@@ -61,13 +56,12 @@ define([
                     // correct all sliders but slack proportionally
                     for (var j = 0; j < l; j++) {
                         if (i != slack) {
-                            axes[j].axisValue = instance.formatAxisValue(ratio * axes[j].axisValue);
+                            axes[j].axisValue = (ratio * axes[j].axisValue).toFixed(1);
                         }
                     }
                 }
-                instance.updateMetapolationValues();
-                // trigger the design space to redraw
-                designSpace.parent.currentDesignSpaceTrigger++;
+                instance.setMetapolationValues();
+                console.log("wants a design space redraw");
             }
             
             function format(value) {

--- a/app/lib/ui/metapolator/design-space-panel/control/control-directive.js
+++ b/app/lib/ui/metapolator/design-space-panel/control/control-directive.js
@@ -52,23 +52,15 @@ define([
                 };
                 
                 initialBuildGraphics();
-                
-                // todo, when changing design space, automatically the current instance is changed as well
-                // this causes 2 triggers for redraw, where only the designspace redraw function should be fired
-                
-                scope.$watch('model.parent.currentInstanceTrigger', function() {
+
+                scope.$watch('model.parent.currentInstance', function() {
                     return softRedraw();
                 });
-                
-                scope.$watch('model.parent.currentDesignSpaceTrigger', function() {
+
+                scope.$watchCollection('[model.parent.currentDesignSpace, model.axes.length, model.slack]', function() {
                     return redrawFunction();
                 });
-                
-                scope.$watch('model.parent.nrOfAxesTrigger', function() {
-                    // for now using a full redraw. We can make this more specific later on
-                    return redrawFunction();
-                });
-                            
+
                 function redrawFunction() {
                     removeAll();
                     buildData();

--- a/app/lib/ui/metapolator/design-space-panel/control/control-directive.js
+++ b/app/lib/ui/metapolator/design-space-panel/control/control-directive.js
@@ -20,7 +20,7 @@ define([
             link : function(scope, element, attrs, ctrl) {
                 $(window).resize(function() {
                     initialBuildGraphics();
-                    redrawFunction();
+                    scope.redraw();
                 });
                 var dragActive = false
                   , designSpace = null
@@ -57,11 +57,11 @@ define([
                     return softRedraw();
                 });
 
-                scope.$watchCollection('[model.parent.currentDesignSpace, model.axes.length, model.slack]', function() {
-                    return redrawFunction();
+                scope.$watchCollection('[model.parent.currentDesignSpace, model.axes.length]', function() {
+                    return scope.redraw();
                 });
 
-                function redrawFunction() {
+                scope.redraw = function() {
                     removeAll();
                     buildData();
                     if (thisInstance) {
@@ -70,7 +70,7 @@ define([
                     if (inactiveInstances.length > 0) {
                         drawInactiveAxes();
                     }
-                }
+                };
                 
                 function softRedraw() {
                     inactiveLayer.selectAll('*').remove();


### PR DESCRIPTION
This removes all manual administration of triggers for the design space to redraw (the design space is a d3.js based element, so all objects in it cannot make use of the angular binding system, so it needs to know on what event it has to redraw). 
Previous triggers are replace by 3 simple reference watches (currentInstance, currentDesignSpace and currentDesignSpace.slack) and by 1 direct function which is on the same scope.