### PR TITLE
*polation compatibility check

### DIFF
--- a/app/lib/models/MOM/Glyph.js
+++ b/app/lib/models/MOM/Glyph.js
@@ -49,6 +49,55 @@ define([
         clone.setUFOData(this.getUFOData());
     };
 
+    _p._interpolationCompatibilityTests = [
+        function isGlyph(other, collect, strictlyCompatible) {
+            if(!(other instanceof Glyph))
+                return [false, this + ' "'+ this.id + '": other item is not a '
+                                +'Glyph: "' + other +'" (typeof '
+                                + (typeof other) + ').'];
+            return true;
+        }
+      , function checkEssence(other, collect, strictlyCompatible) {
+            var compatible = true
+              , messages = []
+              , otherChildren = other.children
+              , difference
+              , i,l, result
+              ;
+
+            // even if the other children list is longer, but is
+            // compatible in the overlapping set, we don't accept that
+            // (it would work), but it's confusing yet and points to
+            // an accidental one way compatibility.
+            // maybe we can have "patching" glyphs in the future, but
+            // it's not number one on the list.
+            difference = otherChildren.length - this._children.length;
+            if(difference) {
+                compatible = false;
+                messages.push(this + ' "'+this.id+'": '
+                        + (difference > 0 ? 'too many' : 'too few')
+                        + ' child elements (' + difference
+                        + ') in other glyph.');
+                if(!collect)
+                    return [compatible, messages];
+            }
+
+            l = Math.min(this._children.length, otherChildren.length);
+            for(i=0;i<l;i++) {
+                result = this._children[i].isInterpolationCompatible(
+                            otherChildren[i] ,collect, strictlyCompatible);
+                if(result[0])
+                    continue;
+                messages.push(this + ' "'+this.id+'": '
+                            + 'incompatible child at index ' + i +' … ');
+                Array.prototype.push.apply(messages, result[1]);
+                if(!collect)
+                   break;
+            }
+            return [compatible, messages];
+        }
+    ];
+
     Object.defineProperty(_p, 'MOMType', {
         value: 'MOM Glyph'
     });

--- a/app/lib/models/MOM/_Contour.js
+++ b/app/lib/models/MOM/_Contour.js
@@ -22,6 +22,37 @@ define([
     var _p = _Contour.prototype = Object.create(Parent.prototype);
     _p.constructor = _Contour;
 
+    _p._interpolationCompatibilityTests = [
+        function isSameType(other, collect, strictlyCompatible) {
+            if(other.type !== this.type)
+                return [false, this + ':i(' + this.index + '): types are different: '
+                                    + other];
+            return true;
+        }
+      , function checkStructure(other, collect, strictlyCompatible) {
+            var messages = []
+              , compatible
+              ;
+            // At the moment it's easy, we have always the same structure
+            // within the children of any _Contour, so it's enough to count
+            // children:
+            //      contour -> p
+            //      penstroke -> point -> left/center/right
+            //      component
+            // A more complex node can implement its own tests.
+
+            var difference = other.children.length - this._children.length;
+            if(difference !== 0)
+                return [false, this + ':i('+this.index+'): '
+                        + (difference > 0 ? 'too many' : 'too few')
+                         + ' child elements' + ' (' + difference
+                         + ') in other '+other.type+'.'];
+
+
+            return true;
+        }
+    ];
+
     Object.defineProperty(_p, 'glyph', {
         get: function() {
             return this._parent;

--- a/app/lib/models/MOM/_Contour.js
+++ b/app/lib/models/MOM/_Contour.js
@@ -1,9 +1,14 @@
 define([
-    './_Node'
+    'metapolator/errors'
+  , './_Node'
 ], function(
-    Parent
+    errors
+  , Parent
 ) {
     "use strict";
+
+    var MOMError = errors.MOM;
+
     /**
      * All children of a MOM Glyph have to inherit from MOM _Contour.
      */

--- a/app/lib/models/MOM/_Node.js
+++ b/app/lib/models/MOM/_Node.js
@@ -14,8 +14,11 @@ define([
   , bloomfilter
 ) {
     "use strict";
+    /*globals clearTimeout:true, setTimeout:true*/
 
-    var MOMError = errors.MOM;
+    var MOMError = errors.MOM
+      , NotImplementedError = errors.NotImplemented
+      ;
 
     var _id_counter = 0
       , emitterMixinSetup
@@ -117,6 +120,35 @@ define([
         callback(this);
         for(i=0,l=this.children.length;i<l;i++)
             this.children[i].walkTreeDepthFirst(callback);
+    };
+
+    _p._interpolationCompatibilityTests = null;
+    _p.isInterpolationCompatible = function(other, collect /* default: true*/
+                                        , strictlyCompatible/*default: true*/) {
+        if(!this._interpolationCompatibilityTests)
+            throw new NotImplementedError(this + ' does not support the '
+                                +'isInterpolationCompatible interface.');
+
+        var accumulate = collect === undefined ? true : !!collect
+          , strict = strictlyCompatible === undefined ? true : !!strictlyCompatible
+          , compatible = true
+          , messages = []
+          , i,l, test, result
+          ;
+
+        for(i=0,l=this._interpolationCompatibilityTests.length;i<l;i++) {
+            test = this._interpolationCompatibilityTests[i];
+            result = test.call(this, other, accumulate, strictlyCompatible);
+            if(result === true || result[0])
+                continue;//passed;
+            compatible = false;
+            if(typeof result[1] === 'string')
+                messages.push(result[1]);
+            else
+                Array.prototype.push.apply(messages, result[1]);
+            break;
+        }
+        return [compatible, messages];
     };
 
     emitterMixin(_p, emitterMixinSetup);

--- a/app/lib/ui/metapolator/master-panel/master-panel-controller.js
+++ b/app/lib/ui/metapolator/master-panel/master-panel-controller.js
@@ -14,7 +14,7 @@ define([
     "use strict";
     function MasterPanelController($scope, project) {
         this.$scope = $scope;
-        
+
         $scope.removeMasters = function() {
             if ($scope.model.areMastersSelected()) {
                 for (var i = 0, l = $scope.model.masterSequences.length; i < l; i++) {
@@ -25,8 +25,8 @@ define([
                             master.remove();
                         }
                     }
-                } 
-                
+                }
+
             }
         };
 
@@ -134,7 +134,7 @@ define([
         $scope.importUfo_dialog_close = function() {
             $("#importufo_dialog").css("display", "none");
         };
-        
+
         $scope.addMasterToDesignSpace = function (master) {
             var designSpace = $scope.model.currentDesignSpace
               , axes = designSpace.axes
@@ -152,6 +152,13 @@ define([
                 instanceTools.registerInstance(project, newInstance);
                 $scope.model.instanceSequences[0].addInstance(newInstance);
             }  else {
+                var result = designSpace.axes[0].MOMelement
+                    .isInterpolationCompatible(master.MOMelement, true);
+                if(!result[0]) {
+                    console.log('Not compatible:', result[1]);
+                    return;
+                }
+
                 designSpace.addAxis(master);
                 // add this axes to each instance in the design space
                 for (var i = $scope.model.instanceSequences.length - 1; i >= 0; i--) {
@@ -172,7 +179,7 @@ define([
             }
             //$scope.data.checkIfIsLargest();
         };
-        
+
         // angular-ui sortable
         $scope.sortableOptions = {
             handle : '.list-edit',
@@ -193,20 +200,20 @@ define([
                         setColorCursorHelper(true);
                         $(".drop-area").addClass("drag-over");
                     }
-                    
+
                 } else {
                     destroyCursorHelper();
                     $(".drop-area").removeClass("drag-over");
                 }
             },
-            update : function(e, ui) { 
-                
+            update : function(e, ui) {
+
             },
             stop : function(e, ui) {
                 destroyCursorHelper();
                 var element = $(ui.item).find("mtk-master");
                 var master = angular.element(element).isolateScope().model;
-    
+
                 if (isOverDropArea(ui) && !isInDesignSpace(master)) {
                     // push master to design space when dropped on drop-area
                     $scope.addMasterToDesignSpace(master);
@@ -215,7 +222,7 @@ define([
                 $(".drop-area").removeClass("drag-over");
             }
         };
-        
+
         function isOverDropArea(master) {
             if ($scope.model.currentDesignSpace) {
                 var dropLeft = $(".drop-area").offset().left;
@@ -237,22 +244,22 @@ define([
                 return false;
             }
         }
-        
+
         function isInDesignSpace(master) {
             var designSpace = $scope.model.currentDesignSpace;
             for (var i = designSpace.axes.length - 1; i >= 0; i--) {
                 var masterInDS = designSpace.axes[i];
                 if (masterInDS === master) {
                     return true;
-                }   
+                }
             }
             return false;
         }
-        
+
         //cursorhelper functions
         var cursorHelper = false
           , templayer = $('<div class="cursor-helper"></div>')[0];
-    
+
         function createCursorHelper(x, y) {
             cursorHelper = true;
             $(document.body).append(templayer);
@@ -261,19 +268,19 @@ define([
                 'top' : y + 10
             });
         }
-    
+
         function destroyCursorHelper() {
             $(templayer).remove();
             cursorHelper = false;
         }
-    
+
         function setPositionCursorHelper(x, y) {
             $(templayer).css({
                 "left" : x + 10,
                 "top" : y + 10
             });
         }
-    
+
         function setColorCursorHelper(ok) {
             if (ok) {
                 $(templayer).html("+").removeClass("cursor-not-ok");
@@ -281,7 +288,7 @@ define([
                 $(templayer).html("×").addClass("cursor-not-ok");
             }
         }
-        
+
         // hover masters
         $scope.mouseoverMaster = function(master) {
             if (master.display || master.edit) {
@@ -291,7 +298,7 @@ define([
                 });
             }
         };
-    
+
         $scope.mouseleaveMaster = function() {
             $(".specimen-field-masters ul li").removeClass("dimmed");
         };
@@ -301,4 +308,4 @@ define([
     var _p = MasterPanelController.prototype;
 
     return MasterPanelController;
-}); 
+});


### PR DESCRIPTION
fixes #711

I don't know if it is the best location, but to demo it I used the new method here: https://github.com/metapolator/metapolator/pull/718/files#diff-e0af9f44e663e33de578fac6c33a0cb9R155

The method returns a 2 element array: `[true|false, [array of collected incompatibilities] ]`
If `result[0] === true` the masters are compatible and there are no messages in `result[1]`
If `result[0] === false` the masters are incompatible and there are one or more messages in `result[1]`

The message array may look like this:

```js
[
   "<MOM Glyph> "A": too few child elements (-3) in other glyph.",
   "<MOM Glyph> "a": too few child elements (-3) in other glyph.",
   "<MOM Glyph> "a": incompatible child at index 0 … ",
   "<MOM PenStroke>:i(0): too many child elements (6) in other penstroke.",
   "<MOM Glyph> "l": too few child elements (-1) in other glyph.",
   "<MOM Glyph> "o": too many child elements (1) in other glyph.",
   "<MOM Glyph> "o": incompatible child at index 0 … ",
   "<MOM PenStroke>:i(0): too few child elements (-3) in other penstroke.",
   "<MOM Glyph> "p": too few child elements (-5) in other glyph.",
   "<MOM Glyph> "r": too few child elements (-4) in other glyph.",
   "<MOM Glyph> "r": incompatible child at index 0 … ",
   "<MOM PenStroke>:i(0): too many child elements (6) in other penstroke.",
   "<MOM Glyph> "t": too few child elements (-1) in other glyph.",
   "<MOM Glyph> "M": too few child elements (-1) in other glyph."
]
```
Here is a rather extreme example, with a lot of missing glyphs. So we may have to either add a "details" field to some messages, or make them expandable or both: 

```js
[
   "<MOM Master> "master-RozhaOne": missing glyphs in Master "master-regular": .notdef, AE, AEacute, Aacute, Abreve, Acircumflex, Adieresis, Agrave, Amacron, Aogonek, Aring, Atilde, B, C, CR, Cacute, Ccaron, Ccedilla, Cdotaccent, D, Dcaron, Dcroat, E, Eacute, Ebreve, Ecaron, Ecircumflex, Edieresis, Edotaccent, Egrave, Emacron, Eng, Eogonek, Eth, Euro, F, G, Gbreve, Gcircumflex, Gdotaccent, H, Hbar, I, IJ, Iacute, Ibreve, Icircumflex, Idieresis, Idotaccent, Igrave, Imacron, Iogonek, Itilde, J, Jcircumflex, K, L, Lacute, Lcaron, Ldot, Lslash, N, NULL, Nacute, Ncaron, Ntilde, O, OE, Oacute, Obreve, Ocircumflex, Odieresis, Ograve, Ohungarumlaut, Omacron, Oslash, Oslashacute, Otilde, P, Q, R, Racute, Rcaron, S, Sacute, Scaron, Scircumflex, T, Tbar, Tcaron, Thorn, U, Uacute, Ubreve, Ucircumflex, Udieresis, Ugrave, Uhungarumlaut, Umacron, Uogonek, Uring, Utilde, V, W, Wacute, Wcircumflex, Wdieresis, Wgrave, X, Y, Yacute, Ycircumflex, Ydieresis, Ygrave, Z, ZWJ, ZWNJ, ZWSP, Zacute, Zcaron, Zdotaccent, aacute, abreve, acircumflex, acute, acute.cap, adieresis, ae, aeacute, agrave, amacron, ampersand, aogonek, approxequal, aring, asciicircum, asciitilde, asterisk, at, atilde, b, backslash, bar, braceleft, braceright, bracketleft, bracketright, breve, breve.cap, brokenbar, bullet, c, cacute, caron, caron.cap, ccaron, ccedilla, cdotaccent, cedilla, cedilla.cap, cent, circumflex, circumflex.cap, colon, comma, commaaccent, copyright, currency, d, dagger, daggerdbl, dcaron, dcroat, degree, dieresis, dieresis.cap, divide, dollar, dotaccent, dotaccent.cap, dotlessi, dottedcircle, dvA, dvAA, dvAI, dvAU, dvAbbreviationSign, dvAcandra, dvAcute, dvAnudatta, dvAnusvara, dvAnusvara.aMatraI, dvAvagraha, dvB, dvBA, dvBH, dvBHA, dvBH_LA, dvBH_NA, dvBH_R, dvBH_RA, dvBH_R_YA, dvBH_VA, dvBH_YA, dvB_BA, dvB_BHA, dvB_BH_RA, dvB_DA, dvB_DHA, dvB_DH_VA, dvB_JA, dvB_JA_Nukta, dvB_JHA, dvB_J_YA, dvB_LA, dvB_L_YA, dvB_NA, dvB_R, dvB_RA, dvB_SA, dvB_SHA, dvB_TA, dvB_VA, dvB_YA, dvC, dvCA, dvCH, dvCHA, dvCH_NA, dvCH_RA, dvCH_R_YA, dvCH_VA, dvCH_YA, dvC_CA, dvC_CHA, dvC_CH_VA, dvC_MA, dvC_NA, dvC_R, dvC_RA, dvC_YA, dvCandrabindu, dvD, dvDA, dvDA_MatraVocalicR, dvDD, dvDDA, dvDDA_Nukta, dvDDH, dvDDHA, dvDDHA_Nukta, dvDDH_DDHA, dvDDH_Nukta_RA, dvDDH_R, dvDDH_RA, dvDDH_YA, dvDD_DDA, dvDD_DDHA, dvDD_GA, dvDD_NA, dvDD_Nukta_RA, dvDD_R, dvDD_RA, dvDD_VA, dvDD_YA, dvDH, dvDHA, dvDH_MA, dvDH_NA, dvDH_N_YA, dvDH_R, dvDH_RA, dvDH_VA, dvDH_YA, dvD_BA, dvD_BHA, dvD_B_RA, dvD_DA, dvD_DHA, dvD_GA, dvD_GHA, dvD_G_RA, dvD_MA, dvD_NA, dvD_R, dvD_RA, dvD_VA, dvD_YA, dvD_Y_BHA, dvD_Y_RA, dvDanda, dvDoubleDanda, dvE, dvEcandra, dvEight, dvEshort, dvEyelash, dvEyelash_HA, dvEyelash_YA, dvFive, dvFour, dvG, dvGA, dvGA_Nukta, dvGH, dvGHA, dvGH_MA, dvGH_NA, dvGH_R, dvGH_RA, dvGH_YA, dvG_BA, dvG_BHA, dvG_BH_YA, dvG_DA, dvG_DHA, dvG_DH_VA, dvG_DH_YA, dvG_GA, dvG_GHA, dvG_JA, dvG_LA, dvG_MA, dvG_NA, dvG_NNA, dvG_N_YA, dvG_Nukta, dvG_Nukta_R, dvG_Nukta_RA, dvG_R, dvG_RA, dvG_R_YA, dvG_SA, dvG_VA, dvG_YA, dvGlottalStop, dvGrave, dvH, dvHA, dvHA_MatraU, dvHA_MatraUU, dvHA_MatraVocalicR, dvH_LA, dvH_MA, dvH_NA, dvH_NNA, dvH_RA, dvH_VA, dvH_YA, dvI, dvII, dvII_Anusvara, dvJ, dvJA, dvJA_Nukta, dvJH, dvJHA, dvJH_MA, dvJH_NA, dvJH_R, dvJH_RA, dvJH_YA, dvJ_BA, dvJ_DA, dvJ_DDA, dvJ_JA, dvJ_JHA, dvJ_J_NYA, dvJ_J_VA, dvJ_J_YA, dvJ_KA, dvJ_MA, dvJ_NA, dvJ_NY, dvJ_NYA, dvJ_NY_YA, dvJ_Nukta, dvJ_Nukta_JA_Nukta, dvJ_Nukta_R, dvJ_Nukta_RA, dvJ_Nukta_YA, dvJ_R, dvJ_RA, dvJ_TA, dvJ_TTA, dvJ_VA, dvJ_YA, dvK, dvKA, dvKA_Nukta, dvKH, dvKHA, dvKHA_Nukta, dvKH_KHA, dvKH_MA, dvKH_NA, dvKH_Nukta, dvKH_Nukta_MA, dvKH_Nukta_R, dvKH_Nukta_RA, dvKH_Nukta_SA, dvKH_Nukta_SHA, dvKH_Nukta_TA, dvKH_Nukta_VA, dvKH_Nukta_YA, dvKH_R, dvKH_RA, dvKH_SHA, dvKH_TA, dvKH_VA, dvKH_YA, dvK_CA, dvK_DA, dvK_JA, dvK_KA, dvK_KHA, dvK_LA, dvK_MA, dvK_NA, dvK_NNA, dvK_Nukta, dvK_Nukta_BA, dvK_Nukta_KA_Nukta, dvK_Nukta_MA, dvK_Nukta_PHA, dvK_Nukta_PHA_Nukta, dvK_Nukta_R, dvK_Nukta_RA, dvK_Nukta_TA, dvK_PA, dvK_PHA, dvK_P_RA, dvK_R, dvK_RA, dvK_RA.aTrad, dvK_SA, dvK_SHA, dvK_SS, dvK_SSA, dvK_SS_M, dvK_SS_MA, dvK_SS_M_YA, dvK_SS_VA, dvK_SS_YA, dvK_S_DDA, dvK_S_P_LA, dvK_S_P_RA, dvK_S_TA, dvK_S_TTA, dvK_TA, dvK_THA, dvK_TTA, dvK_T_RA, dvK_T_VA, dvK_T_YA, dvK_VA, dvK_V_YA, dvK_YA, dvL, dvLA, dvLL, dvLLA, dvLLA_Nukta, dvLL_YA, dvL_BA, dvL_BH, dvL_BHA, dvL_DA, dvL_DDA, dvL_DDHA, dvL_D_RA, dvL_GA, dvL_HA, dvL_JA, dvL_JA_Nukta, dvL_KA, dvL_KHA, dvL_K_YA, dvL_LA, dvL_L_YA, dvL_MA, dvL_PA, dvL_PHA, dvL_SA, dvL_TA, dvL_THA, dvL_TH_YA, dvL_TTA, dvL_TTHA, dvL_VA, dvL_V_DDA, dvL_YA, dvM, dvMA, dvM_BA, dvM_BH, dvM_BHA, dvM_BH_RA, dvM_BH_VA, dvM_BH_YA, dvM_B_RA, dvM_B_YA, dvM_DA, dvM_HA, dvM_LA, dvM_MA, dvM_NA, dvM_PA, dvM_P_RA, dvM_R, dvM_RA, dvM_SA, dvM_SHA, dvM_TA, dvM_VA, dvM_YA, dvMatraAA, dvMatraAI, dvMatraAI_Anusvara, dvMatraAI_Candrabindu, dvMatraAI_Reph, dvMatraAI_Reph_Anusvara, dvMatraAU, dvMatraAU_Anusvara, dvMatraAU_Reph, dvMatraAU_Reph_Anusvara, dvMatraE, dvMatraE_Anusvara, dvMatraE_Candrabindu, dvMatraE_Reph, dvMatraE_Reph_Anusvara, dvMatraEcandra, dvMatraEshort, dvMatraI, dvMatraI.a01, dvMatraI.a02, dvMatraI.a03, dvMatraI.a04, dvMatraI.a05, dvMatraI.a06, dvMatraI.a07, dvMatraI.a08, dvMatraI.a09, dvMatraI.a10, dvMatraI.a11, dvMatraI.a12, dvMatraI.a13, dvMatraI.a14, dvMatraI.a15, dvMatraI.a16, dvMatraI.a17, dvMatraI.a18, dvMatraI.a19, dvMatraI.a20, dvMatraI.a21, dvMatraI.a22, dvMatraI.a23, dvMatraI.a24, dvMatraI.a25, dvMatraI.a26, dvMatraI.a27, dvMatraI.a28, dvMatraI.a29, dvMatraI.a30, dvMatraI.a31, dvMatraI.a32, dvMatraII, dvMatraII.aLong, dvMatraII_Anusvara, dvMatraII_Anusvara.aLong, dvMatraII_Reph, dvMatraII_Reph.aLong, dvMatraII_Reph_Anusvara, dvMatraII_Reph_Anusvara.aLong, dvMatraO, dvMatraO_Anusvara, dvMatraO_Reph, dvMatraO_Reph_Anusvara, dvMatraOcandra, dvMatraOshort, dvMatraOshort_Anusvara, dvMatraU, dvMatraUU, dvMatraVocalicR, dvMatraVocalicRR, dvN, dvNA, dvNA_Nukta, dvNApost, dvNG, dvNGA, dvNG_GA, dvNG_MA, dvNG_RA, dvNN, dvNNA, dvNN_DDA, dvNN_DDHA, dvNN_MA, dvNN_NNA, dvNN_R, dvNN_RA, dvNN_TTA, dvNN_TTHA, dvNN_VA, dvNN_YA, dvNY, dvNYA, dvNY_CA, dvNY_CHA, dvNY_JA, dvNY_R, dvNY_RA, dvNY_SHA, dvN_BH, dvN_BHA, dvN_BH_VA, dvN_BH_YA, dvN_CA, dvN_CHA, dvN_DA, dvN_DDA, dvN_DHA, dvN_DH_RA, dvN_DH_VA, dvN_DH_YA, dvN_D_RA, dvN_D_VA, dvN_HA, dvN_KA, dvN_K_SA, dvN_MA, dvN_M_YA, dvN_NA, dvN_N_YA, dvN_Nukta, dvN_Nukta_R, dvN_Nukta_RA, dvN_PA, dvN_PHA, dvN_PH_RA, dvN_P_RA, dvN_R, dvN_RA, dvN_S, dvN_SA, dvN_S_M_YA, dvN_S_TTA, dvN_S_YA, dvN_TA, dvN_THA, dvN_TH_VA, dvN_TH_YA, dvN_TTA, dvN_T_RA, dvN_T_SA, dvN_T_YA, dvN_VA, dvN_YA, dvNine, dvNukta, dvO, dvOcandra, dvOm, dvOne, dvOshort, dvP, dvPA, dvPH, dvPHA, dvPHA_Nukta, dvPH_JA, dvPH_LA, dvPH_NA, dvPH_Nukta, dvPH_Nukta_JA_Nukta, dvPH_Nukta_PHA_Nukta, dvPH_Nukta_R, dvPH_Nukta_RA, dvPH_Nukta_SA, dvPH_Nukta_TA, dvPH_PA, dvPH_PHA, dvPH_R, dvPH_RA, dvPH_SHA, dvPH_TA, dvPH_TTA, dvPH_YA, dvP_LA, dvP_MA, dvP_NA, dvP_PA, dvP_PHA, dvP_R, dvP_RA, dvP_SA, dvP_TA, dvP_TTA, dvP_TTHA, dvP_T_YA, dvP_VA, dvP_YA, dvR, dvRA, dvRA_MatraU, dvRA_MatraUU, dvRA_Nukta, dvRApost, dvRashtraSign, dvReph, dvReph.aMatraI, dvReph_Anusvara, dvReph_Anusvara.aMatraI, dvS, dvSA, dvSH, dvSHA, dvSHA_MatraVocalicR, dvSH_CA, dvSH_CHA, dvSH_KA, dvSH_KA_Nukta, dvSH_LA, dvSH_MA, dvSH_NA, dvSH_RA, dvSH_SHA, dvSH_TA, dvSH_TTA, dvSH_VA, dvSH_VA.aSimp, dvSH_YA, dvSS, dvSSA, dvSS_KA, dvSS_K_RA, dvSS_MA, dvSS_M_YA, dvSS_NNA, dvSS_NN_YA, dvSS_PA, dvSS_PHA, dvSS_P_RA, dvSS_SSA, dvSS_TTA, dvSS_TTHA, dvSS_TTH_RA, dvSS_TTH_YA, dvSS_TT_RA, dvSS_TT_VA, dvSS_TT_YA, dvSS_VA, dvSS_YA, dvS_BA, dvS_DA, dvS_JA, dvS_KA, dvS_KHA, dvS_K_RA, dvS_K_VA, dvS_LA, dvS_MA, dvS_M_YA, dvS_NA, dvS_PA, dvS_PHA, dvS_P_RA, dvS_R, dvS_RA, dvS_SA, dvS_TA, dvS_THA, dvS_TH_YA, dvS_TTA, dvS_T_R, dvS_T_RA, dvS_T_VA, dvS_T_YA, dvS_VA, dvS_YA, dvSeven, dvSix, dvT, dvTA, dvTH, dvTHA, dvTH_NA, dvTH_R, dvTH_RA, dvTH_VA, dvTH_YA, dvTT, dvTTA, dvTTH, dvTTHA, dvTTH_NA, dvTTH_R, dvTTH_RA, dvTTH_TTHA, dvTTH_YA, dvTT_GA, dvTT_NA, dvTT_R, dvTT_RA, dvTT_TTA, dvTT_TTHA, dvTT_VA, dvTT_YA, dvT_KA, dvT_KHA, dvT_KH_NA, dvT_KH_RA, dvT_K_RA, dvT_K_SSA, dvT_K_VA, dvT_K_YA, dvT_LA, dvT_MA, dvT_M_YA, dvT_NA, dvT_N_YA, dvT_PA, dvT_PHA, dvT_P_LA, dvT_P_RA, dvT_R, dvT_RA, dvT_R_KA.aTrad, dvT_R_YA, dvT_SA, dvT_S_NA, dvT_S_VA, dvT_S_YA, dvT_T, dvT_TA, dvT_THA, dvT_T_VA, dvT_T_YA, dvT_VA, dvT_YA, dvThree, dvTwo, dvU, dvUU, dvUdatta, dvV, dvVA, dvV_HA, dvV_LA, dvV_NA, dvV_R, dvV_RA, dvV_VA, dvV_YA, dvVirama, dvVisarga, dvVocalicL, dvVocalicLL, dvVocalicR, dvVocalicRR, dvY, dvYA, dvYA_Nukta, dvYApost, dvY_NA, dvY_Nukta, dvY_Nukta_R, dvY_Nukta_RA, dvY_R, dvY_RA, dvY_YA, dvZero, eacute, ebreve, ecaron, ecircumflex, edieresis, edotaccent, egrave, eight, ellipsis, emacron, emdash, endash, eng, eogonek, equal, estimated, eth, exclam, exclamdown, f, f_b, f_f, f_f_b, f_f_h, f_f_i, f_f_j, f_f_k, f_f_l, f_j, f_k, fi, five, fl, florin, four, fraction, gbreve, gcircumflex, gdotaccent, germandbls, grave, grave.cap, greater, greaterequal, guillemotleft, guillemotright, guilsinglleft, guilsinglright, h, hbar, hcircumflex, hungarumlaut, hungarumlaut.cap, hyphen, i, i.alt, iacute, ibreve, icircumflex, idieresis, igrave, ij, imacron, indianrupee, infinity, iogonek, itfLogo, itfStar, itilde, j, j.alt, jcircumflex, k, lacute, lcaron, ldot, less, lessequal, logicalnot, lozenge, lslash, m, macron, macron.cap, minus, multiply, n, nacute, ncaron, nine, notequal, ntilde, numbersign, oacute, obreve, ocircumflex, odieresis, oe, ogonek, ogonek.cap, ograve, ohungarumlaut, omacron, one, onehalf, onequarter, onesuperior, oslash, oslashacute, otilde, paragraph, parenleft, parenright, partialdiff, percent, period, periodcentered, perthousand, plus, plusminus, product, q, question, questiondown, quotedbl, quotedblbase, quotedblleft, quotedblright, quoteleft, quoteright, quotesinglbase, quotesingle, racute, radical, rcaron, registered, ring, ring.cap, s, sacute, scaron, scircumflex, section, semicolon, seven, six, slash, sterling, summation, tbar, tcaron, thorn, three, threequarters, threesuperior, tilde, tilde.cap, trademark, two, twosuperior, u, uacute, ubreve, ucircumflex, udieresis, ugrave, uhungarumlaut, umacron, underscore, uni00B5, uni0122, uni0123, uni0136, uni0137, uni013B, uni013C, uni0145, uni0146, uni0156, uni0157, uni015E, uni015F, uni0162, uni0163, uni0218, uni0219, uni2113, uni2126, uni2206, uogonek, uring, utilde, v, w, wacute, wcircumflex, wdieresis, wgrave, x, y, yacute, ycircumflex, ydieresis, yen, ygrave, z, zacute, zcaron, zdotaccent, zero, zerosuperior.",
   "<MOM Glyph> "A": too many child elements (3) in other glyph.",
   "<MOM Glyph> "M": too many child elements (1) in other glyph.",
   "<MOM Glyph> "a": too many child elements (3) in other glyph.",
   "<MOM Glyph> "a": incompatible child at index 0 … ",
   "<MOM PenStroke>:i(0): too few child elements (-6) in other penstroke.",
   "<MOM Glyph> "l": too many child elements (1) in other glyph.",
   "<MOM Glyph> "o": too few child elements (-1) in other glyph.",
   "<MOM Glyph> "o": incompatible child at index 0 … ",
   "<MOM PenStroke>:i(0): too many child elements (3) in other penstroke.",
   "<MOM Glyph> "p": too many child elements (5) in other glyph.",
   "<MOM Glyph> "r": too many child elements (4) in other glyph.",
   "<MOM Glyph> "r": incompatible child at index 0 … ",
   "<MOM PenStroke>:i(0): too few child elements (-6) in other penstroke.",
   "<MOM Glyph> "t": too many child elements (1) in other glyph."
]

```




